### PR TITLE
fix: jar에서 File 시스템이 아닌 InputStream으로 파일을 읽을 수 있도록 함

### DIFF
--- a/modules/infrastructure/log-writer/src/main/java/com/whoz_in/log_writer/config/NetworkConfig.java
+++ b/modules/infrastructure/log-writer/src/main/java/com/whoz_in/log_writer/config/NetworkConfig.java
@@ -32,7 +32,7 @@ public class NetworkConfig {
 
         //JSON 파일 읽기
         try {
-            map = mapper.readValue(resource.getFile(), Map.class);
+            map = mapper.readValue(resource.getInputStream(), Map.class);
         } catch (IOException e) {
             throw new RuntimeException(jsonPath + " 로드 실패");
         }


### PR DESCRIPTION
## ✨ PR 내용
중첩된 jar 구조에서 리소스를 File 시스템 경로로 접근하는 것이 불가능하므로 input stream으로 파일을 읽어들이도록 함