### PR TITLE
[FIX] connectedTime 이 null 일 경우 버그 수정

### DIFF
--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/application/active/view/ActiveDevice.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/application/active/view/ActiveDevice.java
@@ -20,6 +20,7 @@ public record ActiveDevice(
     }
 
     public Duration continuousTime(){
+        if(Objects.isNull(connectedTime)) return Duration.ZERO;
         if(Objects.isNull(disConnectedTime)) return Duration.between(connectedTime, LocalDateTime.now()).abs();
         return Duration.between(connectedTime, disConnectedTime);
     }


### PR DESCRIPTION
## 📌 관련 이슈
#
## ✨ PR 내용
- 사용자가 기기 등록을 한 후, 한 번도 Active 상태가 되지 않은 기기일 경우 connectedTime 이 null 입니다.
- 데이터베이스에서 이 값을 그대로 가져와 연산을 수행할 경우 NPE 가 발생하므로 이와 맞게 처리를 해줍니다.

## 🤓 리뷰어에게

