### PR TITLE
[REFACTOR] 기기 삭제 시, 기기가 가지고 있던 연속 접속 시간 정보 누적 로직 추가

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
@@ -1,6 +1,7 @@
 package com.whoz_in.api_query_jpa.device.active.event;
 
 import com.whoz_in.api_query_jpa.device.active.ActiveDeviceRepository;
+import com.whoz_in.api_query_jpa.shared.util.ActiveTimeUpdateWriter;
 import com.whoz_in.main_api.shared.domain.device.active.event.DeviceDeletedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -12,10 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ActiveDeviceDeletedEventHandler {
 
     private final ActiveDeviceRepository activeDeviceRepository;
+    private final ActiveTimeUpdateWriter activeTimeUpdateWriter;
 
     @Transactional
     @EventListener(DeviceDeletedEvent.class)
     public void handle(DeviceDeletedEvent event) {
+        activeTimeUpdateWriter.updateDailyTime(event.deviceId());
         activeDeviceRepository.deleteById(event.deviceId());
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
#237 

## ✨ PR 내용
- 기기 삭제시 , 해당 기기가 가진 시간 정보를 누적합니다.

## 🤓 리뷰어에게

