### PR TITLE
[FEAT] Event Retry

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
@@ -3,9 +3,12 @@ package com.whoz_in.api_query_jpa.device.active.event;
 import com.whoz_in.api_query_jpa.device.active.ActiveDeviceRepository;
 import com.whoz_in.api_query_jpa.shared.util.ActiveTimeUpdateWriter;
 import com.whoz_in.main_api.shared.domain.device.active.event.DeviceDeletedEvent;
+import com.whoz_in.main_api.shared.event.fail.FailedEventStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component("ActiveDeviceDeletedEventHandler")
@@ -15,11 +18,15 @@ public class ActiveDeviceDeletedEventHandler {
     private final ActiveDeviceRepository activeDeviceRepository;
     private final ActiveTimeUpdateWriter activeTimeUpdateWriter;
 
-    @Transactional
+    @Transactional(isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRED)
     @EventListener(DeviceDeletedEvent.class)
     public void handle(DeviceDeletedEvent event) {
-        activeTimeUpdateWriter.updateDailyTime(event.deviceId());
-        activeDeviceRepository.deleteById(event.deviceId());
+        try {
+            activeTimeUpdateWriter.updateDailyTime(event.deviceId());
+            activeDeviceRepository.deleteById(event.deviceId());
+        } catch (Exception e) {
+            FailedEventStore.add(event);
+        }
     }
 
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventRetryer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventRetryer.java
@@ -1,7 +1,9 @@
 package com.whoz_in.main_api.shared.event.fail;
 
 import com.whoz_in.domain.shared.event.EventBus;
+import com.whoz_in.main_api.shared.event.ApplicationEvent;
 import com.whoz_in.main_api.shared.event.Events;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,10 +19,14 @@ public class FailedEventRetryer {
 
     @Scheduled(fixedRate = 1000 * 30)
     public void retry() {
-        FailedEventStore.poll().forEach(event -> {
-            log.info("[이벤트 재시도] {} ", event.getClass().getName());
-            eventPublisher.publishEvent(event);
-        });
+        List<ApplicationEvent> events = FailedEventStore.poll();
+
+        if (!events.isEmpty()) {
+            events.forEach(event -> {
+                log.info("[이벤트 재시도] {} ", event.getClass().getName());
+                eventPublisher.publishEvent(event);
+            });
+        }
     }
 
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventRetryer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventRetryer.java
@@ -1,0 +1,26 @@
+package com.whoz_in.main_api.shared.event.fail;
+
+import com.whoz_in.domain.shared.event.EventBus;
+import com.whoz_in.main_api.shared.event.Events;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FailedEventRetryer {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(fixedRate = 1000 * 30)
+    public void retry() {
+        FailedEventStore.poll().forEach(event -> {
+            log.info("[이벤트 재시도] {} ", event.getClass().getName());
+            eventPublisher.publishEvent(event);
+        });
+    }
+
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
@@ -1,0 +1,22 @@
+package com.whoz_in.main_api.shared.event.fail;
+
+import com.whoz_in.main_api.shared.event.ApplicationEvent;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+
+// 다른 모듈에서 사용할 수 있도록 static 으로 구성
+public class FailedEventStore {
+
+    // TODO: 어떤 자료구조를 써야 할지?
+    private static final Queue<ApplicationEvent> eventStore = new ArrayDeque<>();
+
+    public static void add(ApplicationEvent event) {
+        eventStore.add(event);
+    }
+
+    public static List<ApplicationEvent> poll() {
+        return eventStore.stream().toList();
+    }
+
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
@@ -5,16 +5,19 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 // 다른 모듈에서 사용할 수 있도록 static 으로 구성
 public class FailedEventStore {
-
-    // TODO: 어떤 자료구조를 써야 할지?
-    private static final Queue<ApplicationEvent> eventStore = new ConcurrentLinkedDeque<>();
+    private static final Queue<ApplicationEvent> eventStore = new ConcurrentLinkedQueue<>();
+    private static final int MAX_SIZE = 10000; // 메모리 누수 방지용 최대 크기
 
     public static void add(ApplicationEvent event) {
-        eventStore.add(event);
+        if (eventStore.size() < MAX_SIZE) {
+            eventStore.add(event);
+        } else {
+            eventStore.poll();
+        }
     }
 
     public static List<ApplicationEvent> poll() {
@@ -22,5 +25,4 @@ public class FailedEventStore {
         eventStore.clear();
         return events;
     }
-
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/event/fail/FailedEventStore.java
@@ -2,21 +2,25 @@ package com.whoz_in.main_api.shared.event.fail;
 
 import com.whoz_in.main_api.shared.event.ApplicationEvent;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 // 다른 모듈에서 사용할 수 있도록 static 으로 구성
 public class FailedEventStore {
 
     // TODO: 어떤 자료구조를 써야 할지?
-    private static final Queue<ApplicationEvent> eventStore = new ArrayDeque<>();
+    private static final Queue<ApplicationEvent> eventStore = new ConcurrentLinkedDeque<>();
 
     public static void add(ApplicationEvent event) {
         eventStore.add(event);
     }
 
     public static List<ApplicationEvent> poll() {
-        return eventStore.stream().toList();
+        List<ApplicationEvent> events = new ArrayList<>(eventStore);
+        eventStore.clear();
+        return events;
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
#239 

## ✨ PR 내용
- 이벤트 재시도 로직을 추가합니다.
  - 실패한 이벤트는 저장소에 저장
  - 이벤트 Retryer 가 실패한 이벤트를 다시 발행합니다.
- 이벤트 재시도 로직을 적용합니다.

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 디바이스 삭제 처리 시 트랜잭션과 오류 관리가 개선되어, 문제 발생 시 안정적으로 기록되고 대응됩니다.
  - 실패한 이벤트를 주기적으로 재처리하는 자동화 시스템을 도입하여, 시스템의 신뢰성과 안정성이 향상되었습니다.
  - 실패한 이벤트를 저장하는 메커니즘이 추가되어, 최대 10,000개의 이벤트를 관리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->