### PR TITLE
[REFACTOR] 동방 현황 조회 로직 수정

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/DeviceJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/DeviceJpaViewer.java
@@ -56,4 +56,11 @@ public class DeviceJpaViewer implements DeviceViewer {
         List<Device> devices = deviceRepository.findAllByMemberId(ownerId);
         return new DeviceCount(devices.size());
     }
+
+    @Override
+    public List<DevicesStatus> findDevicesStatusAll(List<UUID> ownerIds) {
+        return ownerIds.stream()
+                .map(this::findDevicesStatus)
+                .toList();
+    }
 }

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/ActiveDeviceJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/ActiveDeviceJpaViewer.java
@@ -20,7 +20,7 @@ public class ActiveDeviceJpaViewer implements ActiveDeviceViewer {
 
         if(activeDevice == null) return Optional.empty();
 
-        return Optional.of(createOptionalActiveDevice(activeDevice));
+        return Optional.of(createActiveDevice(activeDevice));
     }
 
     @Override
@@ -28,11 +28,18 @@ public class ActiveDeviceJpaViewer implements ActiveDeviceViewer {
         List<ActiveDeviceEntity> entities = activeDeviceRepository.findAll();
 
         return entities.stream()
-                .map(this::createOptionalActiveDevice)
+                .map(this::createActiveDevice)
                 .toList();
     }
 
-    private ActiveDevice createOptionalActiveDevice(ActiveDeviceEntity entity){
+    @Override
+    public List<ActiveDevice> findAllByDeviceId(List<String> deviceIds) {
+        return activeDeviceRepository.findByDeviceIds(deviceIds.stream().map(UUID::fromString).toList()).stream()
+                .map(this::createActiveDevice)
+                .toList();
+    }
+
+    private ActiveDevice createActiveDevice(ActiveDeviceEntity entity){
         return new ActiveDevice(
                 entity.getDeviceId(),
                 entity.getConnectedAt(),

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
@@ -18,7 +18,6 @@ public class MemberJpaViewer implements MemberViewer {
     private final MemberRepository repository;
     private final ActiveDeviceRepository activeDeviceRepository;
     private final MemberConnectionInfoRepository connectionInfoRepository;
-    private final MemberRepository memberRepository;
 
     @Override
     public Optional<MemberAuthInfo> findAuthInfoByLoginId(String loginId) {
@@ -50,7 +49,7 @@ public class MemberJpaViewer implements MemberViewer {
 
     @Override
     public List<MemberInfo> findAllMemberInfo() {
-        return memberRepository.findAll().stream().map(this::toMemberInfo).toList();
+        return repository.findAll().stream().map(this::toMemberInfo).toList();
     }
 
     private MemberConnectionInfo toMemberConnectionInfo(com.whoz_in.api_query_jpa.member.MemberConnectionInfo entity){

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
@@ -6,6 +6,7 @@ import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberConnectionInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberInfo;
 import com.whoz_in.main_api.query.member.application.MemberViewer;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,33 +18,54 @@ public class MemberJpaViewer implements MemberViewer {
     private final MemberRepository repository;
     private final ActiveDeviceRepository activeDeviceRepository;
     private final MemberConnectionInfoRepository connectionInfoRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public Optional<MemberAuthInfo> findAuthInfoByLoginId(String loginId) {
         return repository.findByLoginId(loginId)
-                .map(member -> new MemberAuthInfo(member.getId(), member.getLoginId(), member.getEncodedPassword()));
+                .map(this::toMemberAuthInfo);
     }
 
     @Override
     public Optional<MemberInfo> findNameByMemberId(String memberId) {
         return repository.findById(UUID.fromString(memberId))
-                .map(member -> new MemberInfo(member.getGeneration(), member.getName()));
+                .map(this::toMemberInfo);
     }
 
     @Override
     public Optional<MemberConnectionInfo> findConnectionInfo(String memberId) {
         return connectionInfoRepository.findByMemberId(UUID.fromString(memberId))
-                .map(connectInfo ->
-                        new MemberConnectionInfo(
-                        connectInfo.getMemberId(),
-                        connectInfo.getDailyTime(),
-                        connectInfo.getTotalTime(),
-                        connectInfo.isActive())
-                );
+                .map(this::toMemberConnectionInfo);
     }
 
     @Override
     public Optional<MemberDetailInfo> findDetailByMemberId(UUID memberId) {
-        return repository.findById(memberId).map(member -> new MemberDetailInfo(memberId, member.getName(), member.getGeneration(), member.getPosition(), member.getStatusMessage()));
+        return repository.findById(memberId).map(this::toMemberDetailInfo);
+    }
+
+    @Override
+    public List<MemberConnectionInfo> findAllMemberConnectionInfo() {
+        return connectionInfoRepository.findAll().stream().map(this::toMemberConnectionInfo).toList();
+    }
+
+    @Override
+    public List<MemberInfo> findAllMemberInfo() {
+        return memberRepository.findAll().stream().map(this::toMemberInfo).toList();
+    }
+
+    private MemberConnectionInfo toMemberConnectionInfo(com.whoz_in.api_query_jpa.member.MemberConnectionInfo entity){
+        return new MemberConnectionInfo(entity.getMemberId(), entity.getDailyTime(), entity.getTotalTime(), entity.isActive());
+    }
+
+    private MemberInfo toMemberInfo(com.whoz_in.api_query_jpa.member.Member entity){
+        return new MemberInfo(entity.getGeneration(), entity.getName());
+    }
+
+    private MemberAuthInfo toMemberAuthInfo(com.whoz_in.api_query_jpa.member.Member entity){
+        return new MemberAuthInfo(entity.getId(), entity.getLoginId(), entity.getEncodedPassword());
+    }
+
+    private MemberDetailInfo toMemberDetailInfo(com.whoz_in.api_query_jpa.member.Member entity){
+        return new MemberDetailInfo(entity.getId(), entity.getName(), entity.getGeneration(), entity.getPosition(), entity.getStatusMessage());
     }
 }

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberJpaViewer.java
@@ -58,7 +58,7 @@ public class MemberJpaViewer implements MemberViewer {
     }
 
     private MemberInfo toMemberInfo(com.whoz_in.api_query_jpa.member.Member entity){
-        return new MemberInfo(entity.getGeneration(), entity.getName());
+        return new MemberInfo(entity.getId(), entity.getPosition(), entity.getStatusMessage(), entity.getGeneration(), entity.getName());
     }
 
     private MemberAuthInfo toMemberAuthInfo(com.whoz_in.api_query_jpa.member.Member entity){

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/application/active/view/ActiveDeviceViewer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/application/active/view/ActiveDeviceViewer.java
@@ -12,4 +12,6 @@ public interface ActiveDeviceViewer extends Viewer {
         return findByDeviceId(deviceId).orElseThrow(()->new IllegalArgumentException("No ActiveDevice Find"));
     }
 
+    List<ActiveDevice> findAllByDeviceId(List<String> deviceIds);
+
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/view/DeviceViewer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/device/view/DeviceViewer.java
@@ -3,7 +3,9 @@ package com.whoz_in.main_api.query.device.view;
 import com.whoz_in.main_api.query.device.application.DeviceOwner;
 import com.whoz_in.main_api.query.device.application.DeviceCount;
 import com.whoz_in.main_api.query.device.application.DevicesStatus;
+import com.whoz_in.main_api.query.device.application.DevicesStatus.DeviceStatus;
 import com.whoz_in.main_api.query.shared.application.Viewer;
+import java.util.List;
 import java.util.UUID;
 
 public interface DeviceViewer extends Viewer {
@@ -15,4 +17,6 @@ public interface DeviceViewer extends Viewer {
     DeviceOwner findDeviceOwner(UUID deviceId);
     // 사용자가 등록한 device 개수를 반환
     DeviceCount findDeviceCount(UUID ownerId);
+
+    List<DevicesStatus> findDevicesStatusAll(List<UUID> ownerIds);
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/MemberViewer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/MemberViewer.java
@@ -5,6 +5,7 @@ import com.whoz_in.main_api.query.member.application.view.MemberConnectionInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberInfo;
 import com.whoz_in.main_api.query.shared.application.Viewer;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +14,6 @@ public interface MemberViewer extends Viewer {
     Optional<MemberInfo> findNameByMemberId(String memberId);
     Optional<MemberConnectionInfo> findConnectionInfo(String memberId);
     Optional<MemberDetailInfo> findDetailByMemberId(UUID memberId);
+    List<MemberConnectionInfo> findAllMemberConnectionInfo();
+    List<MemberInfo> findAllMemberInfo();
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -118,6 +118,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
         Set<UUID> memberIds = new HashSet<>();
         memberConnectionInfos.forEach(memberConnectionInfo -> memberIds.add(memberConnectionInfo.memberId()));
         return memberIds.stream()
+                .parallel()
                 .collect(Collectors.toMap(
                         MemberId::new,
                         memberId -> {
@@ -132,6 +133,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
         Set<UUID> memberIds = new HashSet<>();
         memberInfos.forEach(memberInfo -> memberIds.add(memberInfo.memberId()));
         return memberIds.stream()
+                .parallel()
                 .collect(Collectors.toMap(
                         MemberId::new,
                         memberId -> {
@@ -193,6 +195,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
         Set<UUID> memberIds = new HashSet<>();
         activeDevices.forEach(activeDevice -> memberIds.add(findDeviceOwnerId(activeDevice.deviceId())));
         return memberIds.stream()
+                .parallel()
                 .collect(Collectors.toMap(
                         MemberId::new,
                         memberId -> {

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Handler
 @RequiredArgsConstructor
@@ -38,6 +39,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
     private final RequesterInfo requesterInfo;
 
     @Override
+    @Transactional
     public MembersInRoomResponse handle(MembersInRoom query) {
         validateRegisteredDeviceCount(requesterInfo.getMemberId());
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -1,7 +1,9 @@
 package com.whoz_in.main_api.query.member.application.query;
 
+import com.whoz_in.domain.device.model.DeviceId;
 import com.whoz_in.domain.member.model.MemberId;
 import com.whoz_in.main_api.query.device.application.DeviceCount;
+import com.whoz_in.main_api.query.device.application.DevicesStatus.DeviceStatus;
 import com.whoz_in.main_api.query.member.application.response.MemberInRoomResponse;
 import com.whoz_in.main_api.query.member.application.response.MembersInRoomResponse;
 import com.whoz_in.main_api.query.device.application.active.view.ActiveDevice;
@@ -22,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
@@ -42,27 +45,59 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
         int size = query.size();
         String sortType = query.sortType();
 
+        // 응답용 리스트
         List<MemberInRoomResponse> responses = new ArrayList<>();
 
-        List<ActiveDevice> activeDevices = activeDeviceViewer.findAll();
+        // 모든 멤버 정보 조회
+        List<MemberInfo> memberInfos = memberViewer.findAllMemberInfo();
+
+        // 모든 멤버 접속 정보 조회
+        List<MemberConnectionInfo> memberConnectionInfos = memberViewer.findAllMemberConnectionInfo();
+
+        // 모든 회원의 기기 정보 조회
+        Map<MemberId, List<DeviceStatus>> devicesStatusByMemberId = createDevicesStatusMap(memberInfos); // Map<MemberId, List<DeviceStatus>>
+
+        List<DeviceId> deviceIds = devicesStatusByMemberId.values().stream()
+                .flatMap(List::stream)
+                .map(DeviceStatus::deviceId)
+                .map(DeviceId::new)
+                .toList();
+
+        // 모든 회원의 ActiveDevice 정보 조회
+        List<ActiveDevice> activeDevices = activeDeviceViewer.findAllByDeviceId(deviceIds.stream().map(DeviceId::id).map(UUID::toString).toList());
+
+        Map<MemberId, MemberConnectionInfo> memberConnectionInfoByMemberId = createMemberConnectionInfoMap(memberConnectionInfos);
+
         Map<MemberId, List<ActiveDevice>> activeDevicesByMemberId = createMemberDeviceMap(activeDevices);
 
         if(!activeDevices.isEmpty()) {
 
             int start = page * size;
-            int end = Math.min((start + size), activeDevicesByMemberId.keySet().size());
+            int end = Math.min((start + size), memberInfos.size());
 
-            List<MemberId> memberIds = activeDevicesByMemberId.keySet().stream().toList();
+            List<MemberId> memberIds = memberInfos.stream().map(MemberInfo::memberId).map(MemberId::new).toList();
 
             for (int i = start; i < end; i++) {
 
                 MemberId memberId = memberIds.get(i);
-                List<ActiveDevice> activeDevicesByMember = activeDevicesByMemberId.get(memberId);
-                MemberConnectionInfo connectionInfo = memberViewer.findConnectionInfo(memberId.id().toString()).get();
+                List<DeviceStatus> deviceStatuses = devicesStatusByMemberId.get(memberId);
 
-                MemberInRoomResponse oneResponse = toResponse(memberId, activeDevicesByMember, connectionInfo);
+                if(!deviceStatuses.isEmpty()) {
 
-                responses.add(oneResponse);
+                    List<ActiveDevice> activeDevicesByMember = activeDevicesByMemberId.get(memberId);
+                    MemberConnectionInfo connectionInfo = memberConnectionInfoByMemberId.get(memberId);
+
+                    MemberInRoomResponse oneResponse = toResponse(memberId, activeDevicesByMember, connectionInfo);
+
+                    responses.add(oneResponse);
+                }
+                // 어떠한 기기도 등록하지 않은 사용자일 경우
+                else {
+                    responses.add(MemberInRoomResponse.nonDeviceRegisterer(
+                            memberInfos.get(i).generation(),
+                            memberInfos.get(i).memberId().toString(),
+                            memberInfos.get(i).memberName()));
+                }
             }
 
             // TODO : 정렬 자동화
@@ -75,6 +110,34 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
         }
 
         return new MembersInRoomResponse(responses, 0);
+    }
+
+    private Map<MemberId, MemberConnectionInfo> createMemberConnectionInfoMap(
+            List<MemberConnectionInfo> memberConnectionInfos) {
+
+        Set<UUID> memberIds = new HashSet<>();
+        memberConnectionInfos.forEach(memberConnectionInfo -> memberIds.add(memberConnectionInfo.memberId()));
+        return memberIds.stream()
+                .collect(Collectors.toMap(
+                        MemberId::new,
+                        memberId -> {
+                            return memberConnectionInfos.stream().filter(info -> info.memberId().equals(memberId)).findFirst()
+                                    .orElse(new MemberConnectionInfo(memberId, Duration.ZERO, Duration.ZERO, false));
+                        }
+                ));
+    }
+
+    private Map<MemberId, List<DeviceStatus>> createDevicesStatusMap(List<MemberInfo> memberInfos) {
+
+        Set<UUID> memberIds = new HashSet<>();
+        memberInfos.forEach(memberInfo -> memberIds.add(memberInfo.memberId()));
+        return memberIds.stream()
+                .collect(Collectors.toMap(
+                        MemberId::new,
+                        memberId -> {
+                            return deviceViewer.findDevicesStatus(memberId).devices(); // TODO: 많은 IO 작업 줄이기
+                        }
+                ));
     }
 
     private void validateRegisteredDeviceCount(MemberId memberId) {

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -39,7 +39,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
     private final RequesterInfo requesterInfo;
 
     @Override
-    @Transactional
+    @Transactional // TODO: 병렬 스트림 내부에서 발생하는 Lazy 로딩 예외 방지를 위한 트랜잭셔널
     public MembersInRoomResponse handle(MembersInRoom query) {
         validateRegisteredDeviceCount(requesterInfo.getMemberId());
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/response/MemberInRoomResponse.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/response/MemberInRoomResponse.java
@@ -10,4 +10,15 @@ public record MemberInRoomResponse(
     String totalActiveTime,
     boolean isActive
 ) implements Response {
+
+    public static MemberInRoomResponse nonDeviceRegisterer(int generation, String memberId, String memberName) {
+        return new MemberInRoomResponse(
+                generation,
+                memberId,
+                memberName,
+                "0시간 0분",
+                "0시간 0분",
+                false
+        );
+    }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/view/MemberInfo.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/view/MemberInfo.java
@@ -1,8 +1,13 @@
 package com.whoz_in.main_api.query.member.application.view;
 
+import com.whoz_in.domain.member.model.Position;
 import com.whoz_in.main_api.query.shared.application.View;
+import java.util.UUID;
 
 public record MemberInfo(
+        UUID memberId,
+        String position,
+        String statusMessage,
         int generation,
         String memberName
 ) implements View {


### PR DESCRIPTION
## 📌 관련 이슈
#236 

## ✨ PR 내용
- 조회 시 ActiveDevice 기준으로 조회하는 것이 아닌, Member 기준으로 조회합니다.

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 다중 소유자 및 기기 ID를 활용해 기기 상태와 활성 기기를 한 번에 조회할 수 있는 기능이 추가되었습니다.
  - 모든 회원의 연결 정보와 세부 정보(회원 ID, 직위, 상태 메시지 등)를 일괄 조회할 수 있게 되었습니다.
  - 기기를 등록하지 않은 회원에 대해 기본 응답을 생성하는 기능이 도입되었습니다.

- **리팩토링**
  - 기기 및 회원 데이터의 변환 로직을 최적화하여 코드의 일관성과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->