### PR TITLE
[FEAT] voc 기능에 제목 추가

### DIFF
--- a/modules/domain/src/main/java/com/whoz_in/domain/feedback/event/FeedbackCreated.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/feedback/event/FeedbackCreated.java
@@ -8,5 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public final class FeedbackCreated extends DomainEvent {
-    private final Feedback feedback;
+    private final String title;
+    private final String content;
+    private final String memberId;
 }

--- a/modules/domain/src/main/java/com/whoz_in/domain/feedback/model/Feedback.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/feedback/model/Feedback.java
@@ -13,12 +13,14 @@ import lombok.Getter;
 @AllArgsConstructor(access =  AccessLevel.PRIVATE)
 public final class Feedback extends AggregateRoot {
     private final FeedbackId id;
+    private final String title;
     private final String content;
     private final MemberId writer;
 
-    public static Feedback create(String content, MemberId writer) {
+    public static Feedback create(String title, String content, MemberId writer) {
         Feedback feedback = Feedback.builder()
                 .id(new FeedbackId())
+                .title(title)
                 .content(content)
                 .writer(writer)
                 .build();
@@ -26,9 +28,10 @@ public final class Feedback extends AggregateRoot {
         return feedback;
     }
 
-    public static Feedback load(FeedbackId id, String content, MemberId writer) {
+    public static Feedback load(FeedbackId id, String title, String content, MemberId writer) {
         return Feedback.builder()
                 .id(id)
+                .title(title)
                 .content(content)
                 .writer(writer)
                 .build();

--- a/modules/domain/src/main/java/com/whoz_in/domain/feedback/model/Feedback.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/feedback/model/Feedback.java
@@ -24,7 +24,7 @@ public final class Feedback extends AggregateRoot {
                 .content(content)
                 .writer(writer)
                 .build();
-        feedback.register(new FeedbackCreated(feedback));
+        feedback.register(new FeedbackCreated(title,content,writer.id().toString()));
         return feedback;
     }
 

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/feedback/FeedbackConverter.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/feedback/FeedbackConverter.java
@@ -12,6 +12,7 @@ public class FeedbackConverter extends BaseConverter<FeedbackEntity, Feedback> {
     public FeedbackEntity from(Feedback feedback) {
         return new FeedbackEntity(
                 feedback.getId().id(),
+                feedback.getTitle(),
                 feedback.getContent(),
                 feedback.getWriter().id()
         );
@@ -22,6 +23,7 @@ public class FeedbackConverter extends BaseConverter<FeedbackEntity, Feedback> {
     public Feedback to(FeedbackEntity entity) {
         return Feedback.load(
                 new FeedbackId(entity.getId()),
+                entity.getTitle(),
                 entity.getContent(),
                 new MemberId(entity.getMemberId())
         );

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/feedback/FeedbackEntity.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/feedback/FeedbackEntity.java
@@ -18,13 +18,17 @@ public class FeedbackEntity extends BaseEntity {
     private UUID id;
 
     @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
     private String content;
 
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     private UUID memberId;
 
-    public FeedbackEntity(UUID id, String content, UUID memberId) {
+    public FeedbackEntity(UUID id, String title, String content, UUID memberId) {
         this.id = id;
+        this.title = title;
         this.content = content;
         this.memberId = memberId;
     }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
@@ -3,6 +3,7 @@ package com.whoz_in.main_api.command.feedback.application;
 import com.whoz_in.main_api.command.shared.application.Command;
 
 public record FeedbackSend(
+        String title,
         String content
 ) implements Command {
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
@@ -1,9 +1,23 @@
 package com.whoz_in.main_api.command.feedback.application;
 
+import com.whoz_in.domain.shared.Nullable;
+import com.whoz_in.main_api.command.feedback.exception.ContentLengthExceedException;
+import com.whoz_in.main_api.command.feedback.exception.TitleLengthExceededException;
 import com.whoz_in.main_api.command.shared.application.Command;
 
 public record FeedbackSend(
-        String title,
-        String content
+        @Nullable String title,
+        @Nullable String content
 ) implements Command {
+    public static final int MAX_LENGTH_TITLE = 30;
+    public static final int MAX_LENGTH_CONTENT = 500;
+
+    public FeedbackSend {
+        if (title.length() > MAX_LENGTH_TITLE) {
+            throw TitleLengthExceededException.EXCEPTION;
+        }
+        if (content.length() > MAX_LENGTH_CONTENT) {
+            throw ContentLengthExceedException.EXCEPTION;
+        }
+    }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSend.java
@@ -13,10 +13,10 @@ public record FeedbackSend(
     public static final int MAX_LENGTH_CONTENT = 500;
 
     public FeedbackSend {
-        if (title.length() > MAX_LENGTH_TITLE) {
+        if (title != null && title.length() > MAX_LENGTH_TITLE) {
             throw TitleLengthExceededException.EXCEPTION;
         }
-        if (content.length() > MAX_LENGTH_CONTENT) {
+        if (content != null && content.length() > MAX_LENGTH_CONTENT) {
             throw ContentLengthExceedException.EXCEPTION;
         }
     }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSendHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/application/FeedbackSendHandler.java
@@ -20,6 +20,7 @@ public class FeedbackSendHandler implements CommandHandler<FeedbackSend, Void> {
     @Override
     public Void handle(FeedbackSend cmd) {
         Feedback feedback = Feedback.create(
+                cmd.title(),
                 cmd.content(),
                 requesterInfo.getMemberId()
         );

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/ContentLengthExceedException.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/ContentLengthExceedException.java
@@ -1,0 +1,12 @@
+package com.whoz_in.main_api.command.feedback.exception;
+
+import com.whoz_in.main_api.shared.application.ApplicationException;
+
+public class ContentLengthExceedException extends ApplicationException {
+    public static final ContentLengthExceedException EXCEPTION = new ContentLengthExceedException();
+    public ContentLengthExceedException() {
+        super(
+                "5002", "본문 내용은 500자까지만 작성 가능합니다."
+        );
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/TitleLengthExceededException.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/TitleLengthExceededException.java
@@ -1,0 +1,12 @@
+package com.whoz_in.main_api.command.feedback.exception;
+
+import com.whoz_in.main_api.shared.application.ApplicationException;
+
+public class TitleLengthExceededException extends ApplicationException {
+  public static final TitleLengthExceededException EXCEPTION = new TitleLengthExceededException();
+    public TitleLengthExceededException() {
+        super(
+                "5001", "제목은 50자까지 작성가능합니다."
+        );
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/TitleLengthExceededException.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/feedback/exception/TitleLengthExceededException.java
@@ -6,7 +6,7 @@ public class TitleLengthExceededException extends ApplicationException {
   public static final TitleLengthExceededException EXCEPTION = new TitleLengthExceededException();
     public TitleLengthExceededException() {
         super(
-                "5001", "제목은 50자까지 작성가능합니다."
+                "5001", "제목은 30자까지 작성가능합니다."
         );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #217 

## ✨ PR 내용

## 🤓 리뷰어에게
확인 부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 피드백 제출 양식에 제목 입력란이 추가되었습니다.  
  - 이제 사용자는 피드백을 보낼 때 제목과 내용을 함께 입력할 수 있어, 보다 명확하고 구체적인 의견 전달이 가능합니다.  
  - 피드백 생성 시 제목 길이에 대한 제한이 추가되어, 제목이 30자를 초과할 경우 예외가 발생합니다.  
  - 피드백 내용의 길이도 제한이 있으며, 500자를 초과할 경우 예외가 발생합니다.  
  - 피드백 생성 이벤트의 구조가 변경되어, 제목, 내용 및 작성자 ID를 포함하도록 업데이트되었습니다.  
  - 피드백 데이터 변환 로직이 개선되어 제목 속성이 양방향으로 처리됩니다.  
- **Bug Fixes**
  - 피드백 생성 시 제목과 내용을 포함하도록 수정되었습니다.  
- **New Exceptions**
  - 제목 길이 초과 및 내용 길이 초과에 대한 새로운 예외 클래스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->