### PR TITLE
[REFACTOR] 동방 현확 파악 로직을 수정합니다.

### DIFF
--- a/.github/workflows/network-api.yml
+++ b/.github/workflows/network-api.yml
@@ -1,4 +1,4 @@
-name: network-api ?? ???
+name: network-api 워크 플로우
 
 on:
     push:
@@ -7,11 +7,11 @@ on:
 
 jobs:
     test:
-        name: ?????
+        name: 테스트하기
         uses: ./.github/workflows/ci.yml
 
     deploy:
-        name: ????
+        name: 배포하기
         needs: test
         uses: ./.github/workflows/deploy.yml
         secrets:

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/monitor/MonitorLogEntityRepository.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/monitor/MonitorLogEntityRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MonitorLogEntityRepository extends JpaRepository<MonitorLogEntity, String> {
 
+    @Query("SELECT m FROM MonitorLogEntity m WHERE m.updatedAt > :updatedAt ORDER BY m.updatedAt DESC")
     List<MonitorLogEntity> findByUpdatedAtAfterOrderByUpdatedAtDesc(LocalDateTime updatedAt);
 
     @Query("SELECT 1 FROM MonitorLogEntity m WHERE m.mac = :mac AND m.updatedAt > :time ORDER BY m.updatedAt DESC")

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/monitor/MonitorLogEntityRepository.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/monitor/MonitorLogEntityRepository.java
@@ -5,11 +5,12 @@ import java.util.List;
 import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MonitorLogEntityRepository extends JpaRepository<MonitorLogEntity, String> {
 
     @Query("SELECT m FROM MonitorLogEntity m WHERE m.updatedAt > :updatedAt ORDER BY m.updatedAt DESC")
-    List<MonitorLogEntity> findByUpdatedAtAfterOrderByUpdatedAtDesc(LocalDateTime updatedAt);
+    List<MonitorLogEntity> findByUpdatedAtAfterOrderByUpdatedAtDesc(@Param("updatedAt") LocalDateTime updatedAt);
 
     @Query("SELECT 1 FROM MonitorLogEntity m WHERE m.mac = :mac AND m.updatedAt > :time ORDER BY m.updatedAt DESC")
     boolean existsTopByMacOrderByUpdatedAtDescAfter(String mac, LocalDateTime time);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -120,7 +120,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
                         .build()
                         .sort(responses);
 
-            return new MembersInRoomResponse(responses, memberViewer.countActiveMember().intValue());
+            return new MembersInRoomResponse(responses, memberViewer.countActiveMember().intValue()); // TODO: count 는 응답에서 제외하기 (FE가 반영되면)
         }
 
         return new MembersInRoomResponse(responses, 0);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -108,7 +108,8 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
             if (sortType.equals("asc"))
                 Sorter.<MemberInRoomResponse>builder()
                         .comparator(Comparator.comparing(MemberInRoomResponse::isActive).reversed())
-                        .comparator(Comparator.comparing(MemberInRoomResponse::totalActiveTime))
+                        .comparator(Comparator.comparing(MemberInRoomResponse::totalActiveTime).reversed())
+                        .comparator(Comparator.comparing(MemberInRoomResponse::generation))
                         .comparator(Comparator.comparing(MemberInRoomResponse::memberName))
                         .build()
                         .sort(responses);
@@ -116,6 +117,7 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
             else
                 Sorter.<MemberInRoomResponse>builder()
                         .comparator(Comparator.comparing(MemberInRoomResponse::isActive).reversed())
+                        .comparator(Comparator.comparing(MemberInRoomResponse::generation))
                         .comparator(Comparator.comparing(MemberInRoomResponse::memberName))
                         .build()
                         .sort(responses);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/ActiveDeviceFilter.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/ActiveDeviceFilter.java
@@ -11,6 +11,7 @@ import com.whoz_in.main_api.query.member.application.MemberViewer;
 import com.whoz_in.main_api.shared.domain.device.active.event.ActiveDeviceFinded;
 import com.whoz_in.main_api.shared.event.Events;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -56,13 +57,14 @@ public class ActiveDeviceFilter extends DeviceFilter {
         UUID deviceId = device.getId().id();
         UUID ownerId = device.getMemberId().id();
 
-        ActiveDevice activeDevice = activeDeviceViewer.findByDeviceId(deviceId.toString()).orElse(null);
+        Optional<ActiveDevice> opt = activeDeviceViewer.findByDeviceId(deviceId.toString());
 
-        if(!activeDevice.isActive()) {
-            return true; // 현재 inActive 상태인데, MonitorLog 에 존재할 경우
+        if(opt.isPresent()) {
+            ActiveDevice activeDevice = opt.get();
+            return !activeDevice.isActive(); // active 상태이면 false , inactive 상태이면 true
         }
 
-        // 이미 active 인 경우 이벤트에서 제외
+        log.warn("[ActiveDeviceFilter] device 는 존재하지만, active device 가 존재하지 않는 에러 {}", deviceId);
         return false;
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/DeviceFilter.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/DeviceFilter.java
@@ -6,6 +6,7 @@ import com.whoz_in.domain.network_log.MonitorLog;
 import com.whoz_in.domain.network_log.MonitorLogRepository;
 import com.whoz_in.main_api.query.device.application.active.view.ActiveDeviceViewer;
 import com.whoz_in.main_api.query.member.application.MemberViewer;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -20,6 +21,7 @@ public abstract class DeviceFilter {
     protected final MonitorLogRepository monitorLogRepository;
     protected final ActiveDeviceViewer activeDeviceViewer;
     protected final MemberViewer memberViewer;
+    protected static final Duration MEASURE = Duration.ofMinutes(5);
 
     public DeviceFilter(
             DeviceRepository deviceRepository,
@@ -42,8 +44,8 @@ public abstract class DeviceFilter {
     }
 
     protected Set<MonitorLog> getUniqueMonitorLogs(){
-        LocalDateTime before1Minute = LocalDateTime.now().minusMinutes(1);
-        List<MonitorLog> logs = monitorLogRepository.findByUpdatedAtAfterOrderByUpdatedAtDesc(before1Minute); // 1분 전 로그 조회
+        LocalDateTime before = LocalDateTime.now().minus(MEASURE);
+        List<MonitorLog> logs = monitorLogRepository.findByUpdatedAtAfterOrderByUpdatedAtDesc(before); // 몇 분 간의 로그 조회
         return new HashSet<>(logs); // TODO: 중복 제거
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilter.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilter.java
@@ -25,8 +25,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class InActiveDeviceFilter extends DeviceFilter{
 
-    // MonitorLog 가 마지막으로 뜬지 10분이 되도록 발생하지 않을경우 InActive 처리하는 기준
-    private static final Duration MEASURE = Duration.ofMinutes(5);
+    // MonitorLog 가 마지막으로 뜬지 5분이 되도록 발생하지 않을경우 InActive 처리
 
     public InActiveDeviceFilter(
             DeviceRepository deviceRepository,

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceFixture.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceFixture.java
@@ -3,6 +3,7 @@ package com.whoz_in.main_api.shared.domain.device;
 import com.whoz_in.domain.device.model.Device;
 import com.whoz_in.domain.device.model.DeviceInfo;
 import com.whoz_in.domain.member.model.MemberId;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -17,11 +18,13 @@ public class DeviceFixture {
     }
 
     private static Set<DeviceInfo> randomDeviceInfo(){
-        return Set.of(
-                DeviceInfoFixture.createMockDeviceInfo(),
-                DeviceInfoFixture.createMockDeviceInfo(),
-                DeviceInfoFixture.createMockDeviceInfo()
-        );
+        Set<DeviceInfo> deviceInfos = new HashSet<>();
+
+        deviceInfos.add(DeviceInfoFixture.createMockDeviceInfo());
+        deviceInfos.add(DeviceInfoFixture.createMockDeviceInfo());
+        deviceInfos.add(DeviceInfoFixture.createMockDeviceInfo());
+
+        return deviceInfos;
     }
 
 }

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceFixture.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceFixture.java
@@ -1,0 +1,27 @@
+package com.whoz_in.main_api.shared.domain.device;
+
+import com.whoz_in.domain.device.model.Device;
+import com.whoz_in.domain.device.model.DeviceInfo;
+import com.whoz_in.domain.member.model.MemberId;
+import java.util.Set;
+import java.util.UUID;
+
+public class DeviceFixture {
+
+    public static Device testDevice(UUID ownerId) {
+        return Device.create(
+                new MemberId(ownerId),
+                randomDeviceInfo(),
+                "test_device"
+        );
+    }
+
+    private static Set<DeviceInfo> randomDeviceInfo(){
+        return Set.of(
+                DeviceInfoFixture.createMockDeviceInfo(),
+                DeviceInfoFixture.createMockDeviceInfo(),
+                DeviceInfoFixture.createMockDeviceInfo()
+        );
+    }
+
+}

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceInfoFixture.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/DeviceInfoFixture.java
@@ -1,0 +1,31 @@
+package com.whoz_in.main_api.shared.domain.device;
+
+import com.whoz_in.domain.device.model.DeviceInfo;
+import com.whoz_in.domain.device.model.MacAddress;
+
+public class DeviceInfoFixture {
+
+    private static final String room = "testRoom";
+    private static final String ssid = "testSsid";
+
+    public static DeviceInfo createMockDeviceInfo(){
+        return DeviceInfo.create(
+                room,
+                ssid,
+                MacAddress.create(randomMac())
+        );
+    }
+
+    private static String randomMac(){
+        String result;
+        result = String.format("%02x:%02x:%02x:%02x:%02x:%02x",
+                (int) (Math.random() * 256),
+                (int) (Math.random() * 256),
+                (int) (Math.random() * 256),
+                (int) (Math.random() * 256),
+                (int) (Math.random() * 256),
+                (int) (Math.random() * 256));
+        return result;
+    }
+
+}

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
@@ -11,15 +11,17 @@ import com.whoz_in.main_api.query.device.application.active.view.ActiveDeviceVie
 import com.whoz_in.main_api.query.member.application.MemberViewer;
 import com.whoz_in.main_api.shared.domain.device.DeviceFixture;
 import com.whoz_in.main_api.shared.domain.member.MemberFixture;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class InActiveDeviceFilterTest {
 
     @Mock private DeviceRepository deviceRepository;

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
@@ -1,0 +1,57 @@
+package com.whoz_in.main_api.shared.domain.device.active;
+
+import com.whoz_in.domain.device.DeviceRepository;
+import com.whoz_in.domain.device.model.Device;
+import com.whoz_in.domain.device.model.DeviceInfo;
+import com.whoz_in.domain.device.model.MacAddress;
+import com.whoz_in.domain.member.MemberRepository;
+import com.whoz_in.domain.member.model.Member;
+import com.whoz_in.domain.network_log.MonitorLogRepository;
+import com.whoz_in.main_api.query.device.application.active.view.ActiveDeviceViewer;
+import com.whoz_in.main_api.query.member.application.MemberViewer;
+import com.whoz_in.main_api.shared.domain.device.DeviceFixture;
+import com.whoz_in.main_api.shared.domain.member.MemberFixture;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class InActiveDeviceFilterTest {
+
+    @Mock private DeviceRepository deviceRepository;
+    @Mock private MemberViewer memberViewer;
+    @Mock private MemberRepository memberRepository;
+    @Mock private ActiveDeviceViewer activeDeviceViewer;
+    @Mock private MonitorLogRepository monitorLogRepository;
+
+    @InjectMocks private InActiveDeviceFilter inActiveDeviceFilter;
+
+    @BeforeEach
+    void setUp() {
+        // ActiveDevice , Device , MemberConnection , Member 세팅
+        Member member = MemberFixture.testMember();
+        UUID memberId = member.getId().id();
+
+        Device device = DeviceFixture.testDevice(memberId);
+        UUID deviceId = device.getId().id();
+
+        memberRepository.save(member);
+        deviceRepository.save(device);
+    }
+
+    @Test
+    @DisplayName("5분_동안_monitor_log_가_발생하지_않은_기기는_inActive라고_판단한다")
+    void judgeTest() {
+        // TODO: 테스트 작성
+    }
+
+    @Test
+    @DisplayName("이미_inActive인_기기는_pass한다")
+    void inActivePass(){
+        // TODO: 테스트 작성
+    }
+
+}

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/device/active/InActiveDeviceFilterTest.java
@@ -13,6 +13,7 @@ import com.whoz_in.main_api.shared.domain.device.DeviceFixture;
 import com.whoz_in.main_api.shared.domain.member.MemberFixture;
 import java.util.Set;
 import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,12 +47,14 @@ public class InActiveDeviceFilterTest {
     @DisplayName("5분_동안_monitor_log_가_발생하지_않은_기기는_inActive라고_판단한다")
     void judgeTest() {
         // TODO: 테스트 작성
+        Assertions.assertTrue(true);
     }
 
     @Test
     @DisplayName("이미_inActive인_기기는_pass한다")
     void inActivePass(){
         // TODO: 테스트 작성
+        Assertions.assertTrue(true);
     }
 
 }

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/member/MemberFixture.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/domain/member/MemberFixture.java
@@ -1,0 +1,23 @@
+package com.whoz_in.main_api.shared.domain.member;
+
+import com.whoz_in.domain.member.model.Member;
+import com.whoz_in.domain.member.model.OAuthCredentials;
+import com.whoz_in.domain.member.model.Position;
+import com.whoz_in.domain.member.model.SocialProvider;
+
+public class MemberFixture {
+
+    private static final OAuthCredentials testOAuthCredentials = OAuthCredentials.create(SocialProvider.KAKAO, "testSocialId");
+    private static final Position testPosition = Position.BE;
+    private static final String testName = "testUser";
+
+    public static Member testMember(){
+        return Member.create(
+                testName,
+                testPosition,
+                26,
+                testOAuthCredentials
+        );
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
#250 

## ✨ PR 내용
- InActive <-> Active 불안정하게 왔다 갔다 하는 로직을 수정합니다.
- 동방 현황 조회 API 호출 시, 데이터 정렬 기준을 수정합니다.
  1. active / inActive
  2. dailyActiveTime
- InActiveDeviceFilter 테스트를 위한 테스트 코드를 일부 작성했습니다.
  - MemberFixture
  - DeviceFixture

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 멤버 목록 정렬 로직이 개선되어, 멤버 정보 표시의 일관성과 정확성이 향상되었습니다.
	- 장치의 활성/비활성 기준이 업데이트되어 사용자 경험 개선에 기여합니다.
	- 모니터 로그 조회 기간이 1분에서 5분으로 연장되어, 더 많은 로그 데이터에 접근할 수 있게 되었습니다.
- **Refactor**
	- 데이터 조회 쿼리와 로그 필터링 로직이 업데이트되어, 내부 처리 효율과 오류 감지가 개선되었습니다.
- **Tests**
	- 새로운 테스트 유틸리티와 픽스처가 도입되어, 기능 안정성 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->