### PR TITLE
[FEAT] 토큰 재발급, 로그아웃 기능 구현

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberRepository.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberRepository.java
@@ -21,12 +21,12 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     @Query("SELECT m FROM Member m WHERE m.id IN (SELECT d.memberId FROM Device d WHERE d.id IN (:deviceIds))")
     List<Member> findByDeviceIds(@Param("deviceIds") List<UUID> deviceIds);
 
-    @Query("SELECT m FROM Member m JOIN MemberConnectionInfo mci WHERE m.id=mci.memberId ORDER BY mci.isActive desc")
+    @Query("SELECT m FROM Member m, MemberConnectionInfo mci WHERE m.id=mci.memberId ORDER BY mci.isActive desc")
     List<Member> findAllOrderByStatus();
 
     // TODO: 현재는 동방 현황 조회가 isActive, dailyTime, memberName 순으로 고정되게 정렬
     // TODO: 정렬 조건이 바뀌면, 나중에 동적으로 정렬할 수 있게 변환하기
-    @Query("SELECT m FROM Member m JOIN MemberConnectionInfo mci "
+    @Query("SELECT m FROM Member m, MemberConnectionInfo mci "
             + "WHERE m.id=mci.memberId AND mci.isActive=:isActive "
             + "ORDER BY mci.isActive desc , mci.dailyTime desc , m.name asc")
     List<Member> findByStatus(@Param("isActive") boolean isActive);

--- a/modules/infrastructure/api-redis/src/main/resources/application-redis.yml
+++ b/modules/infrastructure/api-redis/src/main/resources/application-redis.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: ${API_REDIS_HOST}
+      port: ${API_REDIS_PORT}

--- a/modules/main-api/build.gradle
+++ b/modules/main-api/build.gradle
@@ -36,5 +36,5 @@ dependencies {
 
     //main-api 구현 모듈 (runtimeOnly - 순환 의존 방지)
     runtimeOnly project(":api-query-jpa")
-//    runtimeOnly project(":modules:infrastructure:api-redis")
+    runtimeOnly project(":modules:infrastructure:api-redis")
 }

--- a/modules/main-api/build.gradle
+++ b/modules/main-api/build.gradle
@@ -36,5 +36,5 @@ dependencies {
 
     //main-api 구현 모듈 (runtimeOnly - 순환 의존 방지)
     runtimeOnly project(":api-query-jpa")
-    runtimeOnly project(":modules:infrastructure:api-redis")
+    runtimeOnly project(":api-redis")
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LogOut.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LogOut.java
@@ -1,0 +1,10 @@
+package com.whoz_in.main_api.command.member.application.command;
+
+import com.whoz_in.main_api.command.shared.application.Command;
+
+public record LogOut(
+        String memberId,
+        String accessTokenId,
+        String refreshTokenId
+) implements Command {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LogOutHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LogOutHandler.java
@@ -1,0 +1,24 @@
+package com.whoz_in.main_api.command.member.application.command;
+
+import com.whoz_in.main_api.command.member.application.token.RefreshTokenStore;
+import com.whoz_in.main_api.command.shared.application.CommandHandler;
+import com.whoz_in.main_api.shared.application.Handler;
+import lombok.RequiredArgsConstructor;
+
+@Handler
+@RequiredArgsConstructor
+public class LogOutHandler implements CommandHandler<LogOut, Void> {
+
+    private final RefreshTokenStore refreshTokenStore;
+
+    @Override
+    public Void handle(LogOut command) {
+
+        String refreshTokenId = command.refreshTokenId();
+        String accessTokenId = command.accessTokenId();
+
+        refreshTokenStore.save(refreshTokenId);
+
+        return null;
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LoginSuccessTokens.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/LoginSuccessTokens.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 public record LoginSuccessTokens(
         String accessToken,

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2Login.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2Login.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.main_api.command.shared.application.Command;
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2LoginHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2LoginHandler.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.domain.member.model.AccountType;
 import com.whoz_in.domain.member.model.Member;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2SignUp.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2SignUp.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.domain.member.model.Position;
 import com.whoz_in.domain.member.model.SocialProvider;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2SignUpHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberOAuth2SignUpHandler.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.domain.member.MemberRepository;
 import com.whoz_in.domain.member.model.Member;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberSignUp.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberSignUp.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.domain.member.model.Position;
 import com.whoz_in.main_api.command.shared.application.Command;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberSignUpHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/MemberSignUpHandler.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.application;
+package com.whoz_in.main_api.command.member.application.command;
 
 import com.whoz_in.domain.member.MemberRepository;
 import com.whoz_in.domain.member.model.AuthCredentials;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/Reissue.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/Reissue.java
@@ -1,0 +1,9 @@
+package com.whoz_in.main_api.command.member.application.command;
+
+import com.whoz_in.main_api.command.shared.application.Command;
+
+public record Reissue(
+    String memberId,
+    String refreshTokenId
+) implements Command {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/ReissueHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/command/ReissueHandler.java
@@ -1,0 +1,44 @@
+package com.whoz_in.main_api.command.member.application.command;
+
+import com.whoz_in.domain.member.model.AccountType;
+import com.whoz_in.domain.member.model.MemberId;
+import com.whoz_in.main_api.command.member.application.token.RefreshTokenStore;
+import com.whoz_in.main_api.command.shared.application.CommandHandler;
+import com.whoz_in.main_api.shared.application.Handler;
+import com.whoz_in.main_api.shared.jwt.tokens.AccessToken;
+import com.whoz_in.main_api.shared.jwt.tokens.RefreshToken;
+import com.whoz_in.main_api.shared.jwt.tokens.TokenException;
+import com.whoz_in.main_api.shared.jwt.tokens.TokenSerializer;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+
+//TODO: 화이트리스트 방식
+@Handler
+@RequiredArgsConstructor
+public class ReissueHandler implements CommandHandler<Reissue, LoginSuccessTokens> {
+
+    private final TokenSerializer<RefreshToken> rtSerializer;
+    private final TokenSerializer<AccessToken> atSerializer;
+    private final RefreshTokenStore rtStore;
+
+    @Override
+    public LoginSuccessTokens handle(Reissue command) {
+        String tokenId = command.refreshTokenId();
+        String memberId = command.memberId();
+
+        if(!rtStore.isExist(tokenId)){
+            rtStore.save(command.refreshTokenId());
+
+            RefreshToken newRtObj = new RefreshToken(new MemberId(UUID.fromString(memberId)));
+            AccessToken newAtObj = new AccessToken(new MemberId(UUID.fromString(memberId)), AccountType.USER);
+
+            String newRtString = rtSerializer.serialize(newRtObj);
+            String newAtString = atSerializer.serialize(newAtObj);
+
+            return new LoginSuccessTokens(newAtString, newRtString);
+        }
+
+        throw new TokenException("2004", "이미 사용한 리프레시 토큰입니다.");
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
@@ -1,0 +1,9 @@
+package com.whoz_in.main_api.command.member.application.token;
+
+// RefreshToken 을 저장하는 인터페이스
+// 하위 모듈에서 구현한다.
+public interface RefreshTokenStore {
+
+    void save(String refreshTokenId);
+
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
@@ -6,4 +6,6 @@ public interface RefreshTokenStore {
 
     void save(String refreshTokenId);
 
+    boolean isExist(String refreshTokenId);
+
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/RefreshTokenStore.java
@@ -8,4 +8,8 @@ public interface RefreshTokenStore {
 
     boolean isExist(String refreshTokenId);
 
+    void clear();
+
+    void delete(String refreshTokenId);
+
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
@@ -1,11 +1,26 @@
 package com.whoz_in.main_api.command.member.application.token;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
 @Component
 public class StubRefreshTokenStore implements RefreshTokenStore{
 
+    private final Map<String, String> store;
+
+    public StubRefreshTokenStore(){
+        this.store = new ConcurrentHashMap<>();
+    }
+
     @Override
     public void save(String refreshTokenId) {
+        store.put(refreshTokenId, System.currentTimeMillis()+3600000+"");
+    }
+
+    @Override
+    public boolean isExist(String refreshTokenId) {
+        return store.containsKey(refreshTokenId);
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
@@ -1,0 +1,11 @@
+package com.whoz_in.main_api.command.member.application.token;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StubRefreshTokenStore implements RefreshTokenStore{
+
+    @Override
+    public void save(String refreshTokenId) {
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/token/StubRefreshTokenStore.java
@@ -23,4 +23,14 @@ public class StubRefreshTokenStore implements RefreshTokenStore{
     public boolean isExist(String refreshTokenId) {
         return store.containsKey(refreshTokenId);
     }
+
+    @Override
+    public void clear() {
+        store.clear();
+    }
+
+    @Override
+    public void delete(String refreshTokenId) {
+        store.remove(refreshTokenId);
+    }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -4,16 +4,19 @@ import static com.whoz_in.main_api.shared.jwt.JwtConst.ACCESS_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.OAUTH2_TEMP_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.REFRESH_TOKEN;
 
-import com.whoz_in.main_api.command.member.application.LoginSuccessTokens;
-import com.whoz_in.main_api.command.member.application.MemberOAuth2Login;
-import com.whoz_in.main_api.command.member.application.MemberOAuth2SignUp;
-import com.whoz_in.main_api.command.member.application.MemberSignUp;
+import com.whoz_in.main_api.command.member.application.command.LoginSuccessTokens;
+import com.whoz_in.main_api.command.member.application.command.MemberOAuth2Login;
+import com.whoz_in.main_api.command.member.application.command.MemberOAuth2SignUp;
+import com.whoz_in.main_api.command.member.application.command.MemberSignUp;
+import com.whoz_in.main_api.command.member.application.command.Reissue;
 import com.whoz_in.main_api.command.member.presentation.docs.MemberCommandApi;
 import com.whoz_in.main_api.command.shared.application.CommandBus;
 import com.whoz_in.main_api.command.shared.presentation.CommandController;
 import com.whoz_in.main_api.config.security.oauth2.OAuth2UserInfo;
 import com.whoz_in.main_api.config.security.oauth2.OAuth2UserInfoStore;
 import com.whoz_in.main_api.shared.jwt.JwtProperties;
+import com.whoz_in.main_api.shared.jwt.tokens.AccessToken;
+import com.whoz_in.main_api.shared.jwt.tokens.RefreshToken;
 import com.whoz_in.main_api.shared.jwt.tokens.TokenException;
 import com.whoz_in.main_api.shared.jwt.tokens.TokenType;
 import com.whoz_in.main_api.shared.jwt.tokens.OAuth2TempToken;
@@ -33,16 +36,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class MemberController extends CommandController implements MemberCommandApi {
   private final TokenSerializer<OAuth2TempToken> oAuth2TempTokenTokenSerializer;
+  private final TokenSerializer<AccessToken> accessTokenTokenSerializer;
+  private final TokenSerializer<RefreshToken> refreshTokenTokenSerializer;
   private final CookieFactory cookieFactory;
   private final JwtProperties jwtProperties;
   private final OAuth2UserInfoStore oAuth2UserInfoStore;
 
   public MemberController(CommandBus commandBus,
           TokenSerializer<OAuth2TempToken> oAuth2TempTokenTokenSerializer,
+          TokenSerializer<AccessToken> accessTokenTokenSerializer,
+          TokenSerializer<RefreshToken> refreshTokenTokenSerializer,
           CookieFactory cookieFactory, JwtProperties jwtProperties,
           OAuth2UserInfoStore oAuth2UserInfoStore) {
     super(commandBus);
     this.oAuth2TempTokenTokenSerializer = oAuth2TempTokenTokenSerializer;
+    this.accessTokenTokenSerializer = accessTokenTokenSerializer;
+    this.refreshTokenTokenSerializer = refreshTokenTokenSerializer;
     this.cookieFactory = cookieFactory;
     this.jwtProperties = jwtProperties;
     this.oAuth2UserInfoStore = oAuth2UserInfoStore;
@@ -70,6 +79,32 @@ public class MemberController extends CommandController implements MemberCommand
     LoginSuccessTokens tokens = dispatch(new MemberOAuth2Login(oAuth2UserInfo.getSocialId()));
     addTokenCookies(response, tokens);
     return ResponseEntityGenerator.success( "소셜 회원가입 완료", HttpStatus.CREATED);
+  }
+
+  @PostMapping("/api/v1/reissue")
+  public ResponseEntity<SuccessBody<Void>> reissue(
+          @CookieValue(name = ACCESS_TOKEN) Cookie accessTokenCookie,
+          @CookieValue(name = REFRESH_TOKEN) Cookie refreshTokenCookie,
+          HttpServletResponse response
+  ){
+    RefreshToken refreshToken = refreshTokenTokenSerializer.deserialize(refreshTokenCookie.getValue())
+            .orElseThrow(()-> new TokenException("2003", "잘못된 refresh token"));
+
+    removeTokenCookies(response);
+
+    // TODO: 다른 타입을 쓸까?
+    LoginSuccessTokens newTokens = dispatch(new Reissue(refreshToken.getMemberId().toString(), refreshToken.getTokenId().toString()));
+
+    addTokenCookies(response, newTokens);
+    return ResponseEntityGenerator.success("토큰 재발급 완료", HttpStatus.CREATED);
+
+  }
+
+  private void removeTokenCookies(HttpServletResponse response) {
+    Cookie emptyAccess = cookieFactory.createDeletionCookie(ACCESS_TOKEN);
+    Cookie emptyRefresh = cookieFactory.createDeletionCookie(REFRESH_TOKEN);
+    response.addCookie(emptyAccess);
+    response.addCookie(emptyRefresh);
   }
 
   private void addTokenCookies(HttpServletResponse response, LoginSuccessTokens tokens){

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import static com.whoz_in.main_api.shared.jwt.JwtConst.ACCESS_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.OAUTH2_TEMP_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.REFRESH_TOKEN;
 
+import com.whoz_in.main_api.command.member.application.command.LogOut;
 import com.whoz_in.main_api.command.member.application.command.LoginSuccessTokens;
 import com.whoz_in.main_api.command.member.application.command.MemberOAuth2Login;
 import com.whoz_in.main_api.command.member.application.command.MemberOAuth2SignUp;
@@ -111,8 +112,15 @@ public class MemberController extends CommandController implements MemberCommand
           HttpServletResponse response) {
     RefreshToken refreshToken = refreshTokenTokenSerializer.deserialize(rtCookie.getValue())
                     .orElseThrow(()-> new TokenException("2003", "잘못된 refresh token"));
+    AccessToken accessToken = accessTokenTokenSerializer.deserialize(atCookie.getValue())
+                    .orElseThrow(() -> new TokenException("2004", "잘못된 access token"));
 
-    //TODO: rt 블랙리스트 등록
+    LogOut command = new LogOut(
+            accessToken.getMemberId().toString(),
+            accessToken.getTokenId().toString(),
+            refreshToken.getTokenId().toString());
+
+    dispatch(command);
 
     removeTokenCookies(response);
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -84,7 +84,7 @@ public class MemberController extends CommandController implements MemberCommand
   }
 
   @Override
-  @PostMapping("/api/v1/auth/reissue")
+  @PostMapping("/api/v1/reissue")
   public ResponseEntity<SuccessBody<Void>> reissue(
           @CookieValue(name = ACCESS_TOKEN) Cookie atCookie,
           @CookieValue(name = REFRESH_TOKEN) Cookie rtCookie,
@@ -104,7 +104,7 @@ public class MemberController extends CommandController implements MemberCommand
   }
 
   @Override
-  @PostMapping("/api/v1/auth/logout")
+  @PostMapping("/api/v1/logout")
   public ResponseEntity<SuccessBody<Void>> logout(
           @CookieValue(name = ACCESS_TOKEN) Cookie atCookie,
           @CookieValue(name = REFRESH_TOKEN) Cookie rtCookie,

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
@@ -1,6 +1,8 @@
 package com.whoz_in.main_api.command.member.presentation.docs;
 
+import static com.whoz_in.main_api.shared.jwt.JwtConst.ACCESS_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.OAUTH2_TEMP_TOKEN;
+import static com.whoz_in.main_api.shared.jwt.JwtConst.REFRESH_TOKEN;
 
 import com.whoz_in.main_api.command.member.application.command.MemberSignUp;
 import com.whoz_in.main_api.command.member.presentation.MemberOAuthSignUpAdditionalInfo;
@@ -9,11 +11,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.checkerframework.checker.units.qual.C;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "회원", description = "회원 Command Api")
+@Tag(name = "회원, 인증, 인가", description = "회원 Command Api")
 public interface MemberCommandApi {
 
     @Operation(
@@ -27,10 +30,31 @@ public interface MemberCommandApi {
             summary = "소셜 회원가입",
             description = "사용자의 추가 정보를 받고 소셜 회원가입을 진행합니다."
     )
-    public ResponseEntity<SuccessBody<Void>> oAuthSignUp(
+    ResponseEntity<SuccessBody<Void>> oAuthSignUp(
             @CookieValue(name = OAUTH2_TEMP_TOKEN) Cookie oAuth2TempTokenCookie,
             @RequestBody MemberOAuthSignUpAdditionalInfo req,
             HttpServletResponse response
     );
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "액세스 토큰 과 리프레시 토큰을 이용하여, 토큰을 재발급합니다."
+    )
+    ResponseEntity<SuccessBody<Void>> reissue(
+            @CookieValue(name = ACCESS_TOKEN) Cookie accessTokenCookie,
+            @CookieValue(name = REFRESH_TOKEN) Cookie refreshTokenCookie,
+            HttpServletResponse response
+    );
+
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃을 수행합니다."
+    )
+    ResponseEntity<SuccessBody<Void>> logout(
+            @CookieValue(name = ACCESS_TOKEN) Cookie accessTokenCookie,
+            @CookieValue(name = REFRESH_TOKEN) Cookie refreshTokenCookie,
+            HttpServletResponse response
+    );
+
 
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
@@ -8,6 +8,8 @@ import com.whoz_in.main_api.command.member.application.command.MemberSignUp;
 import com.whoz_in.main_api.command.member.presentation.MemberOAuthSignUpAdditionalInfo;
 import com.whoz_in.main_api.shared.presentation.SuccessBody;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -41,9 +43,9 @@ public interface MemberCommandApi {
             description = "액세스 토큰 과 리프레시 토큰을 이용하여, 토큰을 재발급합니다."
     )
     ResponseEntity<SuccessBody<Void>> reissue(
-            @CookieValue(name = ACCESS_TOKEN) Cookie accessTokenCookie,
-            @CookieValue(name = REFRESH_TOKEN) Cookie refreshTokenCookie,
-            HttpServletResponse response
+            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "access token cookie") Cookie accessTokenCookie,
+            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "refresh token cookie") Cookie refreshTokenCookie,
+            @Parameter(hidden = true) HttpServletResponse response
     );
 
     @Operation(
@@ -51,9 +53,9 @@ public interface MemberCommandApi {
             description = "로그아웃을 수행합니다."
     )
     ResponseEntity<SuccessBody<Void>> logout(
-            @CookieValue(name = ACCESS_TOKEN) Cookie accessTokenCookie,
-            @CookieValue(name = REFRESH_TOKEN) Cookie refreshTokenCookie,
-            HttpServletResponse response
+            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "access token cookie") Cookie accessTokenCookie,
+            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "refresh token cookie") Cookie refreshTokenCookie,
+            @Parameter(hidden = true) HttpServletResponse response
     );
 
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
@@ -40,11 +40,11 @@ public interface MemberCommandApi {
 
     @Operation(
             summary = "토큰 재발급",
-            description = "액세스 토큰 과 리프레시 토큰을 이용하여, 토큰을 재발급합니다."
+            description = "액세스 토큰과 리프레시 토큰을 이용하여, 토큰을 재발급합니다."
     )
     ResponseEntity<SuccessBody<Void>> reissue(
-            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "access token cookie") Cookie accessTokenCookie,
-            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "refresh token cookie") Cookie refreshTokenCookie,
+            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "액세스 토큰이 담긴 쿠키") Cookie accessTokenCookie,
+            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "리프레시 토큰이 담긴 쿠키") Cookie refreshTokenCookie,
             @Parameter(hidden = true) HttpServletResponse response
     );
 
@@ -53,8 +53,8 @@ public interface MemberCommandApi {
             description = "로그아웃을 수행합니다."
     )
     ResponseEntity<SuccessBody<Void>> logout(
-            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "access token cookie") Cookie accessTokenCookie,
-            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "refresh token cookie") Cookie refreshTokenCookie,
+            @Parameter(name = "access-token", in = ParameterIn.COOKIE, description = "액세스 토큰이 담긴 쿠키") Cookie accessTokenCookie,
+            @Parameter(name = "refresh-token", in = ParameterIn.COOKIE, description = "리프레시 토큰이 담긴 쿠키") Cookie refreshTokenCookie,
             @Parameter(hidden = true) HttpServletResponse response
     );
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/docs/MemberCommandApi.java
@@ -2,7 +2,7 @@ package com.whoz_in.main_api.command.member.presentation.docs;
 
 import static com.whoz_in.main_api.shared.jwt.JwtConst.OAUTH2_TEMP_TOKEN;
 
-import com.whoz_in.main_api.command.member.application.MemberSignUp;
+import com.whoz_in.main_api.command.member.application.command.MemberSignUp;
 import com.whoz_in.main_api.command.member.presentation.MemberOAuthSignUpAdditionalInfo;
 import com.whoz_in.main_api.shared.presentation.SuccessBody;
 import io.swagger.v3.oas.annotations.Operation;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -136,6 +136,8 @@ public class SecurityFilterChainConfig {
                         "/api/v1/member/**"
                 ).requestMatchers(HttpMethod.POST,
                         "/api/v1/device-register-token",
+                        "/api/v1/reissue",
+                        "/api/v1/logout",
                         "/api/v1/feedback/**"
                         //TODO: 로그아웃 추가
                 ).requestMatchers(HttpMethod.PATCH,

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/oauth2/LoginSuccessHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/oauth2/LoginSuccessHandler.java
@@ -4,9 +4,9 @@ import static com.whoz_in.main_api.shared.jwt.JwtConst.ACCESS_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.OAUTH2_TEMP_TOKEN;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.REFRESH_TOKEN;
 
-import com.whoz_in.main_api.command.member.application.LoginSuccessTokens;
-import com.whoz_in.main_api.command.member.application.MemberOAuth2Login;
-import com.whoz_in.main_api.command.member.application.MemberOAuth2LoginHandler;
+import com.whoz_in.main_api.command.member.application.command.LoginSuccessTokens;
+import com.whoz_in.main_api.command.member.application.command.MemberOAuth2Login;
+import com.whoz_in.main_api.command.member.application.command.MemberOAuth2LoginHandler;
 import com.whoz_in.main_api.shared.jwt.JwtProperties;
 import com.whoz_in.main_api.shared.jwt.tokens.TokenType;
 import com.whoz_in.main_api.shared.jwt.tokens.OAuth2TempToken;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/jwt/tokens/AccessToken.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/jwt/tokens/AccessToken.java
@@ -2,12 +2,22 @@ package com.whoz_in.main_api.shared.jwt.tokens;
 
 import com.whoz_in.domain.member.model.AccountType;
 import com.whoz_in.domain.member.model.MemberId;
+import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public final class AccessToken extends Token {
     private final MemberId memberId;
+    private final UUID tokenId;
     private final AccountType accountType;
+
+    public AccessToken(MemberId memberId, AccountType accountType){
+        this.memberId = memberId;
+        this.accountType = accountType;
+        this.tokenId = UUID.randomUUID();
+    }
+
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/jwt/tokens/AccessTokenSerializer.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/jwt/tokens/AccessTokenSerializer.java
@@ -3,6 +3,7 @@ package com.whoz_in.main_api.shared.jwt.tokens;
 
 import static com.whoz_in.main_api.shared.jwt.JwtConst.ACCOUNT_TYPE;
 import static com.whoz_in.main_api.shared.jwt.JwtConst.MEMBER_ID;
+import static com.whoz_in.main_api.shared.jwt.JwtConst.TOKEN_ID;
 
 import com.whoz_in.domain.member.model.AccountType;
 import com.whoz_in.domain.member.model.MemberId;
@@ -23,14 +24,16 @@ public final class AccessTokenSerializer extends TokenSerializer<AccessToken> {
     protected AccessToken buildToken(Claims claims) {
         MemberId memberId = new MemberId(UUID.fromString(claims.get(MEMBER_ID, String.class)));
         AccountType accountType = AccountType.findAccountType(claims.get(ACCOUNT_TYPE, String.class));
-        return new AccessToken(memberId, accountType);
+        UUID tokenId = UUID.fromString(claims.get(TOKEN_ID, String.class));
+        return new AccessToken(memberId, tokenId, accountType);
     }
 
     @Override
     public Map<String, String> buildClaims(AccessToken accessToken) {
         return Map.of(
                 MEMBER_ID, accessToken.getMemberId().toString(),
-                ACCOUNT_TYPE, accessToken.getAccountType().toString()
+                ACCOUNT_TYPE, accessToken.getAccountType().toString(),
+                TOKEN_ID, accessToken.getTokenId().toString()
         );
     }
 

--- a/modules/main-api/src/main/resources/application.yml
+++ b/modules/main-api/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
       - "classpath:application-domain-jpa.yml"
       - "classpath:application-api-query-jpa.yml"
       - "classpath:application-logging.yml"
+      - "classpath:application-redis.yml"
 
 server:
   port: 2470 # 24시간 운영 + main-api니까 0번째

--- a/modules/main-api/src/test/java/com/whoz_in/main_api/shared/jwt/RefreshTokenStoreTest.java
+++ b/modules/main-api/src/test/java/com/whoz_in/main_api/shared/jwt/RefreshTokenStoreTest.java
@@ -1,0 +1,72 @@
+package com.whoz_in.main_api.shared.jwt;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.whoz_in.main_api.command.member.application.token.RefreshTokenStore;
+import com.whoz_in.main_api.command.member.application.token.StubRefreshTokenStore;
+import java.util.UUID;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class RefreshTokenStoreTest {
+
+    @Mock private final RefreshTokenStore refreshTokenStore;
+
+    public RefreshTokenStoreTest() {
+        this.refreshTokenStore = new StubRefreshTokenStore();
+    }
+
+    @Test
+    @DisplayName("이미_저장된_토큰은_true를_반환한다")
+    void isExistTest(){
+        String tokenId = UUID.randomUUID().toString();
+
+        refreshTokenStore.save(tokenId);
+
+        boolean isExist = refreshTokenStore.isExist(tokenId);
+
+        Assertions.assertTrue(isExist);
+    }
+
+    @Test
+    @DisplayName("삭제한_토큰은_false를_반환한다")
+    void isExistTest2(){
+        String tokenId = UUID.randomUUID().toString();
+
+        refreshTokenStore.save(tokenId);
+        refreshTokenStore.delete(tokenId);
+
+        boolean isExist = refreshTokenStore.isExist(tokenId);
+
+        Assertions.assertFalse(isExist);
+    }
+
+    @Test
+    @DisplayName("저장소를_초기화하면_false를_반환한다")
+    void isExistTest3(){
+        String tokenId = UUID.randomUUID().toString();
+
+        refreshTokenStore.save(tokenId);
+        refreshTokenStore.clear();
+
+        boolean isExist = refreshTokenStore.isExist(tokenId);
+
+        Assertions.assertFalse(isExist);
+    }
+
+    @Test
+    @DisplayName("저장하지_않은_토큰은_false를_반환한다")
+    void isExistTest4(){
+        String tokenId = UUID.randomUUID().toString();
+
+        // refreshTokenStore.save(tokenId);
+
+        boolean isExist = refreshTokenStore.isExist(tokenId);
+
+        Assertions.assertFalse(isExist);
+
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
#148 

## ✨ PR 내용
### 로그아웃 기능을 구현합니다.
  - 화이트리스트 방식의 저장소를 적용합니다.
  - StubRefreshTokenStore 를 구현 해놓았지만, 추후 api-redis 모듈을 사용합니다.

### 토큰 재발급 기능을 구현합니다.
  - 로그아웃 시, 사용한 리프레시 토큰 과 액세스 토큰을 화이트리스트 저장소에서 제거합니다.
  - 화이트리스트 방식의 저장소를 적용합니다.
  - StubRefreshTokenStore 를 구현 해놓았지만, 추후 api-redis 모듈을 사용합니다.

### api-redis 모듈 초기 설정
  - api-redis 모듈 사용을 위한 설정을 추가합니다.
    - host , port , RedisTemplate 빈 등록

## 🤓 리뷰어에게

