### PR TITLE
[FIX] oauth2 로그인 정보 저장소 동시성 문제

### DIFF
--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/oauth2/OAuth2UserInfoStore.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/oauth2/OAuth2UserInfoStore.java
@@ -28,8 +28,7 @@ public class OAuth2UserInfoStore {
 
     public OAuth2UserInfo takeout(String key) {
         UUID uuidKey = UUID.fromString(key);
-        OAuth2UserInfo userInfo = store.getIfPresent(uuidKey);
-        store.invalidate(uuidKey);
+        OAuth2UserInfo userInfo = store.asMap().remove(uuidKey);
         if (userInfo == null) {
             throw new IllegalArgumentException("소셜 로그인 정보를 찾을 수 없습니다.");
         }


### PR DESCRIPTION
로그인 정보를 꺼내고 제거하는 것을 원자적으로 수행하도록 변경하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 보안 관련 캐시 데이터 처리 방식이 개선되어, 사용자 정보의 조회와 제거가 단일 연산으로 수행됩니다.
  - 기존의 오류 처리 방식은 그대로 유지되어 안정성이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->