### PR TITLE
[FIX] 사용자 재실 시간 정밀도 상향

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
@@ -5,7 +5,6 @@ import com.whoz_in.api_query_jpa.member.MemberConnectionInfoRepository;
 import com.whoz_in.api_query_jpa.member.MemberRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
@@ -73,6 +73,9 @@ public class MemberConnectionService {
 
     private void updateDailyTime(MemberConnectionInfo connectionInfo, LocalDateTime disConnectedAt) {
         try {
+            // 선 비활성화
+            connectionInfo.inActiveOn(disConnectedAt);
+
             LocalDateTime inActiveAt = connectionInfo.getInActiveAt();
             LocalDateTime activeAt = connectionInfo.getActiveAt();
 
@@ -81,7 +84,7 @@ public class MemberConnectionService {
 
             Duration continuousTime = Duration.between(activeAt, inActiveAt).abs();
 
-            connectionInfo.inActiveOn(disConnectedAt);
+            // 후 DailyTime 계산
             connectionInfo.addDailyTime(continuousTime);
 
             connectionInfoRepository.save(connectionInfo);

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/shared/service/MemberConnectionService.java
@@ -79,8 +79,8 @@ public class MemberConnectionService {
             LocalDateTime inActiveAt = connectionInfo.getInActiveAt();
             LocalDateTime activeAt = connectionInfo.getActiveAt();
 
-            if(Objects.isNull(activeAt)) activeAt = LocalDateTime.now();
-            if(Objects.isNull(inActiveAt)) inActiveAt = LocalDateTime.now();
+//            if(Objects.isNull(activeAt)) activeAt = LocalDateTime.now();
+//            if(Objects.isNull(inActiveAt)) inActiveAt = LocalDateTime.now();
 
             Duration continuousTime = Duration.between(activeAt, inActiveAt).abs();
 


### PR DESCRIPTION
## 📌 관련 이슈
closes #290 

## ✨ PR 내용
- 사용자의 재실 시간을 계산할 때 정밀도를 높이기 위해서, 마지막으로 발생한 monitor log 의 시간 정보를 활용합니다.
  - 이러한 로직이 동작하지 않아, 정밀도가 떨어지는 오류를 해결합니다.

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 멤버 연결 상태 업데이트 프로세스를 간소화하여, 접속 종료 시각을 더욱 일관되게 반영합니다.
	- 불필요한 조건 검사를 제거해 일일 접속 시간 계산이 명확해지고, 시스템의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->