### PR TITLE
[FEAT] Main api backup

### DIFF
--- a/modules/main-api/docker/backup-service/Dockerfile
+++ b/modules/main-api/docker/backup-service/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    default-mysql-client \
+    gzip \
+    tar \
+    coreutils \
+    cron \
+    gettext \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && echo "Asia/Seoul" > /etc/timezone
+
+WORKDIR /app
+COPY backup-command-db.sh backup-main-api-data.sh cleanup-old-backups.sh crontab.template.txt entrypoint.sh ./
+RUN chmod +x *.sh
+CMD ["./entrypoint.sh"]

--- a/modules/main-api/docker/backup-service/backup-command-db.sh
+++ b/modules/main-api/docker/backup-service/backup-command-db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+BACKUP_DIR="/backup/command-db"
+
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+BACKUP_SQL="$BACKUP_DIR/${TIMESTAMP}.sql"
+FILE_EXTENSION="gz"
+BACKUP_FILE="${BACKUP_SQL}.${FILE_EXTENSION}"
+LOG_FILE="$BACKUP_DIR/backup.log"
+
+mkdir -p "$BACKUP_DIR"
+
+# 백업
+mysqldump -h command-db -uroot --password="$MYSQL_ROOT_PASSWORD" --databases whozin > "$BACKUP_SQL"
+
+if [ $? -eq 0 ]; then
+  # 압축
+  gzip "$BACKUP_SQL"
+  # 크기 계산
+  FILE_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+  echo "✅ 백업 완료: $BACKUP_FILE ($(date)) [크기: $FILE_SIZE]" >> "$LOG_FILE"
+else
+  echo "❌ 백업 실패: $(date)" >> "$LOG_FILE"
+fi
+
+/app/cleanup-old-backups.sh "$BACKUP_DIR" "$FILE_EXTENSION" "$LOG_FILE"

--- a/modules/main-api/docker/backup-service/backup-main-api-data.sh
+++ b/modules/main-api/docker/backup-service/backup-main-api-data.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SOURCE_DIR="/main-api-data"
+BACKUP_DIR="/backup/main-api-data"
+
+LOG_FILE="$BACKUP_DIR/backup.log"
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+FILE_EXTENSION="tar.gz"
+BACKUP_FILE="${BACKUP_DIR}/${TIMESTAMP}.${FILE_EXTENSION}"
+
+# 백업 디렉토리 생성 (최초 실행 대비)
+mkdir -p "$BACKUP_DIR"
+
+# 백업 수행
+tar -czf "$BACKUP_FILE" -C "$SOURCE_DIR" . 2>> "$LOG_FILE"
+
+# 결과 기록
+if [ $? -eq 0 ]; then
+  FILE_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+  echo "✅ 백업 완료: $BACKUP_FILE ($(date)) [크기: $FILE_SIZE]" >> "$LOG_FILE"
+else
+  echo "❌ 백업 실패: $(date)" >> "$LOG_FILE"
+fi
+
+/app/cleanup-old-backups.sh "$BACKUP_DIR" "$FILE_EXTENSION" "$LOG_FILE"

--- a/modules/main-api/docker/backup-service/cleanup-old-backups.sh
+++ b/modules/main-api/docker/backup-service/cleanup-old-backups.sh
@@ -11,7 +11,7 @@ log() {
 }
 
 # 100일 넘은 백업 파일 (오래된 순 정렬)
-mapfile -t DELETE_CANDIDATES < <(find "$TARGET_DIR" -type f  -name "*.${EXTENSION}" | sort)
+mapfile -t DELETE_CANDIDATES < <(find "$TARGET_DIR" -type f -mtime +100 -name "*.${EXTENSION}" | sort)
 NUM_CANDIDATES=${#DELETE_CANDIDATES[@]}
 
 # 항상 1개는 남기고 삭제

--- a/modules/main-api/docker/backup-service/cleanup-old-backups.sh
+++ b/modules/main-api/docker/backup-service/cleanup-old-backups.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# 100일 넘은 백업 파일들을 삭제함 (최소 1개는 남겨둠)
+
+TARGET_DIR="$1"
+EXTENSION="$2"
+LOG_FILE="$3"
+
+log() {
+    echo "$1" >> "$LOG_FILE"
+}
+
+# 100일 넘은 백업 파일 (오래된 순 정렬)
+mapfile -t DELETE_CANDIDATES < <(find "$TARGET_DIR" -type f  -name "*.${EXTENSION}" | sort)
+NUM_CANDIDATES=${#DELETE_CANDIDATES[@]}
+
+# 항상 1개는 남기고 삭제
+for (( i=0; i<NUM_CANDIDATES-1; i++ )); do
+  FILE="${DELETE_CANDIDATES[$i]}"
+  log "오래된 파일 삭제: $FILE"
+  rm -f "$FILE"
+done

--- a/modules/main-api/docker/backup-service/crontab.template.txt
+++ b/modules/main-api/docker/backup-service/crontab.template.txt
@@ -1,0 +1,5 @@
+MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+# 매일 오전 6시 db 백업
+0 6 * * * /app/backup-command-db.sh >> /app/command-db-cron.log 2>&1
+# 매일 오전 6시 main-api 데이터 백업
+0 6 * * * /app/backup-main-api-data.sh >> /app/main-api-data-cron.log 2>&1

--- a/modules/main-api/docker/backup-service/entrypoint.sh
+++ b/modules/main-api/docker/backup-service/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# 환경변수 반영된 crontab 생성
+envsubst < /app/crontab.template.txt > /app/crontab.txt
+rm /app/crontab.template.txt
+crontab /app/crontab.txt
+cron -f

--- a/modules/main-api/docker/deploy.sh
+++ b/modules/main-api/docker/deploy.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 docker container prune -f
 docker image prune -f
-# main-api 이외엔 재실행되지 않음
-# 빌드한 main-api가 변경 사항이 없어도 무조건 재실행 (환경 변수 파일을 변경해도 jar에 포함되지 않기 때문에)
-docker compose up -d --build --force-recreate main-api
+
+docker compose build main-api backup-service
+docker compose up -d --force-recreate main-api # 무조건 재시작 (환경변수 적용때문)
+docker compose up -d backup-service # 변경된 경우에만 재시작

--- a/modules/main-api/docker/docker-compose.yml
+++ b/modules/main-api/docker/docker-compose.yml
@@ -42,6 +42,21 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+  backup-service:
+    container_name: backup-service
+    build:
+      context: backup-service
+      dockerfile: Dockerfile
+    volumes:
+      - ${BASE_BACKUP_DIR}:/backup
+      - main-api-data:/main-api-data:ro
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+    depends_on:
+      main-api:
+        condition: service_started
+      command-db:
+        condition: service_healthy
 
 volumes:
   main-api-data:

--- a/modules/network-api/src/main/java/com/whoz_in/network_api/main_api/InternalAccessUrlWriter.java
+++ b/modules/network-api/src/main/java/com/whoz_in/network_api/main_api/InternalAccessUrlWriter.java
@@ -48,7 +48,7 @@ public final class InternalAccessUrlWriter {
             );
             log.info("'internal access url' updated");
         } catch (ResourceAccessException e){
-            log.error("main api에 접근할 수 없음 : {}", e.getMessage()); //서버가 꺼져있는지 확인
+            log.warn("main api에 접근할 수 없음 : {}", e.getMessage()); //서버가 꺼져있는지 확인
         } catch (HttpClientErrorException.Forbidden e) {
             log.error("Api key 인증 실패 : {}", e.getMessage());
         } catch (Exception e) {


### PR DESCRIPTION
## ✨ PR 내용
main-api의 데이터를 주기적으로 백업하는 기능입니다
어느 환경에서든 안정적으로 백업할 수 있어야 하며, 도커 컴포즈가 컨테이너의 상황을 잘 알고있기 때문에 컴포즈 서비스로 만들었습니다.
매일 새벽 6시에 데이터를 백업하며, 100일 이상 된 백업 파일은 삭제하되 가장 최신 백업 파일 하나는 남겨놓습니다.
mysql과 main-api가 생성한 파일 data(main-api-data) 간 정합성은 보장되지 않습니다. (db 작업 후 파일을 저장하는데 파일 저장 전에 백업하는 경우)

todo: 로컬에선 백업 안할수있도록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 백업 서비스를 위한 자동화된 작업(데이터베이스 백업, API 데이터 백업, 오래된 백업 정리 등)이 추가되었습니다.
	- 새로운 crontab 템플릿이 도입되어 매일 백업 작업이 자동으로 실행됩니다.
- **배포 개선**
	- 메인 API와 백업 서비스의 빌드 및 실행 프로세스가 분리되어, 환경 변수 업데이트 적용과 재시작 제어가 강화되었습니다.
- **스타일**
	- 내부 로깅 메시지의 심각도 조정으로, 모니터링 시 경고 수준이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->