### PR TITLE
[FIX] Device 삭제 로직 수정 및 삭제 메소드 추가

### DIFF
--- a/modules/domain/src/main/java/com/whoz_in/domain/device/DeviceRepository.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/device/DeviceRepository.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 public interface DeviceRepository {
     void save(Device device);
-    void delete(DeviceId deviceId);
+    boolean delete(DeviceId deviceId);
     //해당 mac을 포함하는 device를 찾는 메서드
     Optional<Device> findByMac(String mac);
     Optional<Device> findByDeviceId(DeviceId deviceId);

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/device/DeviceEntityRepository.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/device/DeviceEntityRepository.java
@@ -16,7 +16,7 @@ public interface DeviceEntityRepository extends JpaRepository<DeviceEntity, Long
 
     Optional<DeviceEntity> findById(UUID deviceId);
 
-    void deleteById(UUID deviceId);
+    int deleteById(UUID deviceId);
 
     @Query("SELECT d FROM DeviceEntity d JOIN d.deviceInfoEntity di WHERE di.mac IN (:macs)")
     List<DeviceEntity> findByMacs(@Param("macs") Set<String> macs);

--- a/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/device/DeviceJpaRepository.java
+++ b/modules/infrastructure/domain-jpa/src/main/java/com/whoz_in/domain_jpa/device/DeviceJpaRepository.java
@@ -22,8 +22,9 @@ public class DeviceJpaRepository implements DeviceRepository {
     }
 
     @Override
-    public void delete(DeviceId deviceId) {
-        repository.deleteById(deviceId.id());
+    public boolean delete(DeviceId deviceId) {
+        int result = repository.deleteById(deviceId.id());
+        return result > 0;
     }
 
     @Override

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/device/application/DeviceRemoveHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/device/application/DeviceRemoveHandler.java
@@ -23,8 +23,8 @@ public class DeviceRemoveHandler implements CommandHandler<DeviceRemove, Void> {
     @Override
     public Void handle(DeviceRemove command) {
         memberFinderService.mustExist(requesterInfo.getMemberId());
-        deviceRepository.delete(command.getDeviceId());
-        eventBus.publish(List.of(new DeviceDeleted(command.getDeviceId().id())));
+        boolean result = deviceRepository.delete(command.getDeviceId());
+        if(result) eventBus.publish(List.of(new DeviceDeleted(command.getDeviceId().id())));
         return null;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #293 

## ✨ PR 내용
- Device 삭제 이벤트를 조건부로 발행합니다.
  - 이와 관련하여, Device 삭제 성공 여부를 알 수 있도록 삭제 메소드 로직을 수정하였습니다.

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

다음은 이번 업데이트의 주요 변경 사항입니다.

- **새로운 기능**
  - 기기 삭제 처리 방식이 대폭 개선되어, 삭제 요청 후 즉시 삭제 성공 여부를 확인할 수 있게 되었습니다.
  - 삭제가 정상적으로 완료된 경우에만 후속 작업이 진행되어, 사용자에게 보다 안정적이며 예측 가능한 기기 관리 경험을 제공합니다.
  - 전체 기기 관리 프로세스의 신뢰성이 강화되어, 서비스 활용에 있어 긍정적인 영향을 기대할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->