### PR TITLE
[FEAT] ping 요청을 처리하는 서블릿

### DIFF
--- a/modules/network-api/src/main/java/com/whoz_in/network_api/config/PingServletConfig.java
+++ b/modules/network-api/src/main/java/com/whoz_in/network_api/config/PingServletConfig.java
@@ -1,5 +1,7 @@
 package com.whoz_in.network_api.config;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -37,10 +39,11 @@ public class PingServletConfig {
 
     public static class PingServlet extends HttpServlet {
         @Override
-        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-            resp.setStatus(200);
-            resp.setContentType("text/plain");
-            resp.getWriter().write("pong");
+        protected void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException {
+            res.setStatus(SC_OK);
+            res.setContentType("text/plain");
+            res.getWriter().write("pong");
+            res.getWriter().flush();
         }
     }
 }

--- a/modules/network-api/src/main/java/com/whoz_in/network_api/config/PingServletConfig.java
+++ b/modules/network-api/src/main/java/com/whoz_in/network_api/config/PingServletConfig.java
@@ -1,0 +1,46 @@
+package com.whoz_in.network_api.config;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.apache.catalina.Wrapper;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * ping 응답용 서블릿을 직접 등록하는 설정 클래스
+ * DispatcherServlet을 우회하여 톰캣 레벨에서 처리됨
+ */
+@Configuration
+public class PingServletConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> customizer() {
+        return factory -> {
+            if (factory instanceof TomcatServletWebServerFactory tomcat) {
+                tomcat.addContextCustomizers(context -> {
+                    Wrapper wrapper = context.createWrapper();
+                    wrapper.setName("PingServlet");
+                    wrapper.setServletClass(PingServlet.class.getName());
+                    wrapper.setLoadOnStartup(1);
+                    context.addChild(wrapper);
+                    context.addServletMappingDecoded("/ping", "PingServlet");
+                });
+            }
+        };
+    }
+
+    public static class PingServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            resp.setStatus(200);
+            resp.setContentType("text/plain");
+            resp.getWriter().write("pong");
+        }
+    }
+}


### PR DESCRIPTION
디스패처서블릿 거치지 않고 바로 ping 요청을 처리함
모니터 패킷을 만들기 위해서 만듦

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 서버 상태 확인을 위한 새로운 핑 엔드포인트(/ping)가 추가되었습니다. GET 요청 시 “pong” 응답을 반환하여 서버가 정상적으로 작동 중임을 손쉽게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->