### PR TITLE
[FAET] 회원 Profile 조회 API / 시간 초기화 로직 수정

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/device/active/event/ActiveDeviceDeletedEventHandler.java
@@ -53,7 +53,6 @@ public class ActiveDeviceDeletedEventHandler {
         Optional<MemberConnectionInfo> connectionInfo = connectionInfoRepository.findByMemberId(ownerId);
 
         connectionInfo.ifPresent(ci -> {
-            // TODO: 마지막 기기인지 검증 로직 필요
             if(ci.isActive()) {
                 // 활동 중인데 삭제할 경우 and 삭제한 기기가 Active 인 마지막 기기이면 disconnect
                 deviceConnectionService.disconnectDevice(deviceId, disconnectedAt);

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberRepository.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/MemberRepository.java
@@ -28,6 +28,9 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
             + "ORDER BY mci.isActive desc , mci.dailyTime desc , m.name asc")
     List<Member> findByStatus(@Param("isActive") boolean isActive);
 
+    @Query("SELECT m FROM Member m WHERE m.id NOT IN (SELECT d.memberId FROM Device d) ")
+    List<Member> findNotHaveAnyDevice();
+
     default Member getByDeviceId(UUID deviceId) {
         return findByDeviceId(deviceId).orElseThrow(() -> new IllegalArgumentException("기기의 주인을 찾을 수 없음"));
     }

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/event/MemberDayEndEventHandler.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/event/MemberDayEndEventHandler.java
@@ -6,7 +6,6 @@ import com.whoz_in.api_query_jpa.member.MemberConnectionInfoRepository;
 import com.whoz_in.api_query_jpa.member.MemberRepository;
 import com.whoz_in.api_query_jpa.shared.service.MemberConnectionService;
 import com.whoz_in.main_api.shared.domain.member.event.DayEndEvent;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/event/MemberDayEndEventHandler.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/member/event/MemberDayEndEventHandler.java
@@ -1,0 +1,50 @@
+package com.whoz_in.api_query_jpa.member.event;
+
+import com.whoz_in.api_query_jpa.member.Member;
+import com.whoz_in.api_query_jpa.member.MemberConnectionInfo;
+import com.whoz_in.api_query_jpa.member.MemberConnectionInfoRepository;
+import com.whoz_in.api_query_jpa.member.MemberRepository;
+import com.whoz_in.api_query_jpa.shared.service.MemberConnectionService;
+import com.whoz_in.main_api.shared.domain.member.event.DayEndEvent;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemberDayEndEventHandler {
+
+    private final MemberRepository memberRepository;
+    private final MemberConnectionService connectionService;
+    private final MemberConnectionInfoRepository connectionInfoRepository;
+
+    @EventListener(DayEndEvent.class)
+    @Transactional(isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRES_NEW)
+    public void handle(DayEndEvent event) {
+        // 기기가 없는 사용자들을 찾는다.
+        List<Member> members = memberRepository.findNotHaveAnyDevice();
+
+        if(!members.isEmpty()) {
+            log.info("[DayEndEvent] 발생 : 모든 기기를 삭제한 회원의 접속 시간 정보를 초기화 합니다.");
+
+            List<MemberConnectionInfo> connectionInfos =
+                    connectionInfoRepository.findByMemberIds(members.stream().map(Member::getId).toList());
+
+            connectionInfos.forEach(connectionInfo -> {
+                // 기기가 없는 사용자들은 active 상태가 될 수 없으므로, 호출할 필요가 없다.
+//            connectionService.disconnectMember(connectionInfo.getMemberId(), disConnectedAt);
+                connectionService.updateTotalTime(connectionInfo.getMemberId());
+            });
+            connectionInfoRepository.saveAll(connectionInfos);
+        }
+    }
+
+
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfile.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfile.java
@@ -1,0 +1,8 @@
+package com.whoz_in.main_api.query.member.application.query;
+
+import com.whoz_in.main_api.query.shared.application.Query;
+
+public record MemberProfile(
+        String memberId
+) implements Query {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfileHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfileHandler.java
@@ -1,0 +1,48 @@
+package com.whoz_in.main_api.query.member.application.query;
+
+import com.whoz_in.domain.member.model.MemberId;
+import com.whoz_in.domain.member.model.Position;
+import com.whoz_in.domain.member.service.MemberFinderService;
+import com.whoz_in.main_api.query.member.application.MemberViewer;
+import com.whoz_in.main_api.query.member.application.response.MemberProfileInfo;
+import com.whoz_in.main_api.query.member.application.view.MemberConnectionInfo;
+import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
+import com.whoz_in.main_api.query.member.application.view.MemberInfo;
+import com.whoz_in.main_api.query.shared.application.QueryHandler;
+import com.whoz_in.main_api.shared.application.Handler;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@Handler
+@RequiredArgsConstructor
+public class MemberProfileHandler implements QueryHandler<MemberProfile, MemberProfileInfo> {
+
+    private final MemberViewer memberViewer;
+    private final MemberFinderService memberFinderService;
+
+    @Override
+    public MemberProfileInfo handle(MemberProfile query) {
+        UUID memberId = UUID.fromString(query.memberId());
+
+        memberFinderService.mustExist(new MemberId(memberId));
+
+        MemberConnectionInfo connectionInfo = memberViewer.findConnectionInfo(memberId.toString()).get();
+        MemberInfo memberInfo = memberViewer.findNameByMemberId(memberId.toString()).get();
+
+        Duration duration = connectionInfo.totalTime();
+
+        return new MemberProfileInfo(
+                memberInfo.memberId().toString(),
+                memberInfo.generation(),
+                memberInfo.memberName(),
+                Position.findByName(memberInfo.position()),
+                timeFormat(duration)
+        );
+
+    }
+
+    private String timeFormat(Duration duration){
+        return String.format("%02d시 %02d분", duration.toHours(), duration.toMinutesPart());
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfileHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MemberProfileHandler.java
@@ -6,7 +6,6 @@ import com.whoz_in.domain.member.service.MemberFinderService;
 import com.whoz_in.main_api.query.member.application.MemberViewer;
 import com.whoz_in.main_api.query.member.application.response.MemberProfileInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberConnectionInfo;
-import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
 import com.whoz_in.main_api.query.member.application.view.MemberInfo;
 import com.whoz_in.main_api.query.shared.application.QueryHandler;
 import com.whoz_in.main_api.shared.application.Handler;

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/query/MembersInRoomHandler.java
@@ -147,16 +147,10 @@ public class MembersInRoomHandler implements QueryHandler<MembersInRoom, Members
     private Map<MemberId, MemberConnectionInfo> createMemberConnectionInfoMap(
             List<MemberConnectionInfo> memberConnectionInfos) {
 
-        Set<UUID> memberIds = new HashSet<>();
-        memberConnectionInfos.forEach(memberConnectionInfo -> memberIds.add(memberConnectionInfo.memberId()));
-        return memberIds.stream()
-                .parallel()
+        return memberConnectionInfos.stream()
                 .collect(Collectors.toMap(
-                        MemberId::new,
-                        memberId -> {
-                            return memberConnectionInfos.stream().filter(info -> info.memberId().equals(memberId)).findFirst()
-                                    .orElse(MemberConnectionInfo.empty(memberId));
-                        }
+                        mci -> new MemberId(mci.memberId()),
+                        memberConnectionInfo -> memberConnectionInfo
                 ));
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/response/MemberProfileInfo.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/response/MemberProfileInfo.java
@@ -1,0 +1,13 @@
+package com.whoz_in.main_api.query.member.application.response;
+
+import com.whoz_in.domain.member.model.Position;
+import com.whoz_in.main_api.query.shared.application.Response;
+
+public record MemberProfileInfo(
+        String memberId,
+        int generation,
+        String memberName,
+        Position position,
+        String totalActiveTime
+) implements Response {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/view/MemberConnectionInfo.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/view/MemberConnectionInfo.java
@@ -32,8 +32,4 @@ public record MemberConnectionInfo(
         return Duration.between(activeAt, inActiveAt).abs();
     }
 
-    public static MemberConnectionInfo empty(UUID memberId){
-        return new MemberConnectionInfo(memberId, null, null, null, null, false);
-    }
-
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
@@ -2,8 +2,10 @@ package com.whoz_in.main_api.query.member.presentation;
 
 import com.whoz_in.main_api.query.member.application.query.MemberCountInRoom;
 import com.whoz_in.main_api.query.member.application.query.MemberDetailInfoGet;
+import com.whoz_in.main_api.query.member.application.query.MemberProfile;
 import com.whoz_in.main_api.query.member.application.query.MembersInRoom;
 import com.whoz_in.main_api.query.member.application.response.MemberCountInRoomResponse;
+import com.whoz_in.main_api.query.member.application.response.MemberProfileInfo;
 import com.whoz_in.main_api.query.member.application.response.MembersInRoomResponse;
 import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
 import com.whoz_in.main_api.query.member.presentation.docs.MemberQueryApi;
@@ -14,6 +16,7 @@ import com.whoz_in.main_api.shared.presentation.ResponseEntityGenerator;
 import com.whoz_in.main_api.shared.presentation.SuccessBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +49,11 @@ public class MemberQueryController extends QueryController implements MemberQuer
     @GetMapping("/member")
     public ResponseEntity<SuccessBody<MemberDetailInfo>> getDetailInfo(){
         return ResponseEntityGenerator.success(ask(new MemberDetailInfoGet()), CrudResponseCode.READ);
+    }
+
+    @GetMapping("/member/profile/{memberId}")
+    public ResponseEntity<SuccessBody<MemberProfileInfo>> getProfileInfo(@PathVariable("memberId") String memberId){
+        return ResponseEntityGenerator.success(ask(new MemberProfile(memberId)), CrudResponseCode.READ);
     }
 
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/docs/MemberQueryApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/docs/MemberQueryApi.java
@@ -1,6 +1,7 @@
 package com.whoz_in.main_api.query.member.presentation.docs;
 
 import com.whoz_in.main_api.query.member.application.response.MemberCountInRoomResponse;
+import com.whoz_in.main_api.query.member.application.response.MemberProfileInfo;
 import com.whoz_in.main_api.query.member.application.response.MembersInRoomResponse;
 import com.whoz_in.main_api.query.member.application.view.MemberDetailInfo;
 import com.whoz_in.main_api.shared.presentation.SuccessBody;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "회원", description = "회원 Api")
 public interface MemberQueryApi {
@@ -35,5 +37,11 @@ public interface MemberQueryApi {
             description = "회원 상세정보 (Id, 이름, 기수, 포지션, 상태메세지) 를 조회합니다."
     )
     ResponseEntity<SuccessBody<MemberDetailInfo>> getDetailInfo();
+
+    @Operation(
+            summary = "회원 프로필 조회",
+            description = "memberId에 해당하는 회원의 정보(기수, 이름, 분야, 누적 접속 시간)를 조회합니다."
+    )
+    ResponseEntity<SuccessBody<MemberProfileInfo>> getProfileInfo(@PathVariable("memberId") String memberId);
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
#292 

## ✨ PR 내용
- 회원 Profile 조회 API를 추가합니다.
  - API / Query / Handler 구현.
 
- DailyTime 초기화 로직을 수정합니다.
  - 어떠한 기기도 등록하지 않은 사용자에 대해서도 시간 초기화 로직을 적용합니다.

## 🤓 리뷰어에게

