### PR TITLE
[FEAT] 뱃지 쿼리 응답 수정

### DIFF
--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeJpaViewer.java
@@ -3,7 +3,6 @@ package com.whoz_in.api_query_jpa.badge;
 import com.whoz_in.main_api.query.badge.application.BadgeViewer;
 import com.whoz_in.main_api.query.badge.application.view.BadgeInfo;
 import com.whoz_in.main_api.query.badge.application.view.BadgesOfMember;
-import com.whoz_in.main_api.query.badge.application.view.BadgesOfMember.BadgeOfMember;
 import com.whoz_in.main_api.query.badge.application.view.RegistrableBadges;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -52,10 +51,16 @@ public class BadgeJpaViewer implements BadgeViewer {
     public BadgesOfMember findBadgesOfMember(UUID memberId) {
         List<BadgeMember> badgeMembers = badgeMemberRepo.findByMemberId(memberId);
 
-        List<BadgeOfMember> badgeOfMembers = badgeMembers.stream()
-                .map(bm -> new BadgeOfMember(bm.getBadge_id(), bm.getIs_badge_shown())) // getBadge()로 badgeId 가져오기
-                .collect(Collectors.toList());
+        List<BadgesOfMember.BadgeOfMember> badgeList = badgeMembers.stream()
+                .map(bm -> new BadgesOfMember.BadgeOfMember(
+                        bm.getBadge_id(),
+                        bm.getName(),
+                        bm.getColor_code(),
+                        bm.getDescription(),
+                        bm.getIs_badge_shown()
+                ))
+                .toList();
 
-        return new BadgesOfMember(badgeOfMembers);
+        return new BadgesOfMember(badgeList);
     }
 }

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeJpaViewer.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeJpaViewer.java
@@ -28,6 +28,10 @@ public class BadgeJpaViewer implements BadgeViewer {
 
     @Override
     public RegistrableBadges findRegisterable(UUID memberId) {
+        /*
+        등록가능한 뱃지는 생성된지 12시간이 지나고 개발단 뱃지가 아니어야 함
+        그리고 사용자가 이미 가지고 있는 뱃지가 아니어야 한다.
+         */
         LocalDateTime threshold = LocalDateTime.now().minusHours(12);
         List<Badge> activeBadges = bageRepo.findAllActivatedBadges(threshold);
         List<BadgeMember> badgeMembers = badgeMemberRepo.findByMemberId(memberId);
@@ -38,7 +42,7 @@ public class BadgeJpaViewer implements BadgeViewer {
 
         List<RegistrableBadges.RegistrableBadge> registerableBadgeList = activeBadges.stream()
                 .filter(badge -> !ownedBadgeIds.contains(badge.getId()))
-                .map(badge -> new RegistrableBadges.RegistrableBadge(badge.getId()))
+                .map(badge -> new RegistrableBadges.RegistrableBadge(badge.getId(), badge.getName(), badge.getColor_code(), badge.getDescription()))
                 .toList();
 
         return new RegistrableBadges(registerableBadgeList);

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeMember.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeMember.java
@@ -2,6 +2,7 @@ package com.whoz_in.api_query_jpa.badge;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import org.hibernate.annotations.Immutable;
@@ -13,13 +14,24 @@ import org.hibernate.annotations.Synchronize;
 @Immutable
 @Subselect("SELECT "
         + "bm.member_id AS member_id, "
-        + "bm.badge_id AS badge_id, "
+        + "b.id AS badge_id, "
+        + "b.name AS name, "
+        + "b.color_code AS color_code, "
+        + "b.badge_type AS badge_type, "
+        + "b.created_at AS created_at, "
+        + "b.description AS description, "
         + "bm.is_badge_shown AS is_badge_shown "
-        + "FROM badge_member_entity bm")
-@Synchronize({"badge_member_entity"})
+        + "FROM badge_member_entity bm "
+        + "JOIN badge_entity b ON bm.badge_id = b.id")
+@Synchronize({"badge_member_entity", "badge_entity"})
 public class BadgeMember {
     @Id
     private UUID member_id;
     private UUID badge_id;
+    private String name;
+    private String color_code;
+    private String badge_type;
+    private LocalDateTime created_at;
+    private String description;
     private Boolean is_badge_shown;
 }

--- a/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeRepository.java
+++ b/modules/infrastructure/api-query-jpa/src/main/java/com/whoz_in/api_query_jpa/badge/BadgeRepository.java
@@ -1,5 +1,6 @@
 package com.whoz_in.api_query_jpa.badge;
 
+import com.whoz_in.main_api.query.badge.application.view.BadgesOfMember;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +15,9 @@ public interface BadgeRepository extends JpaRepository<Badge, UUID> {
     Optional<Badge> findById(UUID id);
     @Query("SELECT b FROM Badge b WHERE b.created_at <= :threshold AND b.badge_type = 'USERMADE'")
     List<Badge> findAllActivatedBadges(@Param("threshold") LocalDateTime threshold);
+
+    @Query("SELECT BadgesOfMember.BadgeOfMember( " +
+            "bm.badge_id, bm.name, bm.color_code, bm.description, bm.is_badge_shown) " +
+            "FROM BadgeMember bm WHERE bm.member_id = :memberId")
+    List<BadgesOfMember.BadgeOfMember> findBadgesByMemberId(@Param("memberId") UUID memberId);
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/badge/application/view/BadgesOfMember.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/badge/application/view/BadgesOfMember.java
@@ -9,6 +9,9 @@ public record BadgesOfMember(List<BadgeOfMember> badgeMembers)
         implements Response, View {
     public record BadgeOfMember(
             UUID badgeId,
+            String name,
+            String colorCode,
+            String description,
             Boolean isBadgeShown
     ) {}
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/badge/application/view/RegistrableBadges.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/badge/application/view/RegistrableBadges.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 public record RegistrableBadges(List<RegistrableBadge> registerableBadge)
         implements Response, View {
     public record RegistrableBadge(
-            UUID badgeId
+            UUID badgeId,
+            String name,
+            String colorCode,
+            String description
     ) {}
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #305 

## ✨ PR 내용

기존에 응답을 간략화해 뱃지 아이디만 주던 것들 한 번의 요청으로 끝낼 수 있게 필요한 정보들을 모두 담도록 하였습니다.

수정한 api
- 등록가능한 뱃지 조회
- 멤버의 뱃지 조회
뱃지아이디, 뱃지 이름, 뱃지 색상 코드, 뱃지 설명, + 뱃지 조회 여부 모든 정보들을 담도록 함.

## 🤓 리뷰어에게

api-query nosql mongodb로 하는 거 진짜 필요한 거 BadgeMember하면서 느껴버림

음 BadgeMember에서 필드들이 name보다는 badge_name이렇게 하는 게 좋을 것 같은데 어차피 바뀔거니까 그대로 두어도 괜찮겠죠?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 회원별 뱃지 조회 시, 고유 ID 외에 뱃지 이름, 색상 및 설명 등의 상세 정보가 함께 제공됩니다.
  - 등록 가능한 뱃지 정보에 추가 속성이 포함되어 사용자에게 보다 풍부한 뱃지 데이터를 전달합니다.
  - 개선된 데이터 조회 방식을 통해 뱃지 관련 정보를 명확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->