### PR TITLE
[REFACTOR] member 프로필 조회 URI 변경

### DIFF
--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
@@ -51,7 +51,7 @@ public class MemberQueryController extends QueryController implements MemberQuer
         return ResponseEntityGenerator.success(ask(new MemberDetailInfoGet()), CrudResponseCode.READ);
     }
 
-    @GetMapping("/member/profile/{memberId}")
+    @GetMapping("/member/{memberId}/profile")
     public ResponseEntity<SuccessBody<MemberProfileInfo>> getProfileInfo(@PathVariable("memberId") String memberId){
         return ResponseEntityGenerator.success(ask(new MemberProfile(memberId)), CrudResponseCode.READ);
     }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
@@ -51,7 +51,7 @@ public class MemberQueryController extends QueryController implements MemberQuer
         return ResponseEntityGenerator.success(ask(new MemberDetailInfoGet()), CrudResponseCode.READ);
     }
 
-    @GetMapping("/member/{memberId}/profile")
+    @GetMapping("/members/{memberId}/profile")
     public ResponseEntity<SuccessBody<MemberProfileInfo>> getProfileInfo(@PathVariable("memberId") String memberId){
         return ResponseEntityGenerator.success(ask(new MemberProfile(memberId)), CrudResponseCode.READ);
     }


### PR DESCRIPTION
## 📌 관련 이슈

## ✨ PR 내용
- 멤버의 프로필 조회 엔드 포인트의 URI를 변경합니다.
  - `/api/v1/member/profile/{memberId}` -> `/api/v1/members/{memberId}/profile`

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
  - 회원 프로필 정보 조회 API의 URL 경로가 업데이트되었습니다. 기존의 `/member/profile/{memberId}` 대신 새로운 경로인 `/members/{memberId}/profile`를 사용합니다. 사용자께서 API 호출 시 변경된 URL에 유의해 주시기 바랍니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->